### PR TITLE
Refactor item price model

### DIFF
--- a/prisma/migrations/20240902211258_add_price_id/migration.sql
+++ b/prisma/migrations/20240902211258_add_price_id/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "item_price" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "value" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_items" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "price" TEXT,
+    "url" TEXT,
+    "note" TEXT,
+    "imageUrl" TEXT,
+    "userId" TEXT NOT NULL,
+    "addedById" TEXT NOT NULL,
+    "pledgedById" TEXT,
+    "publicPledgedById" TEXT,
+    "approved" BOOLEAN NOT NULL DEFAULT true,
+    "purchased" BOOLEAN NOT NULL DEFAULT false,
+    "groupId" TEXT,
+    "displayOrder" INTEGER,
+    "itemPriceId" TEXT,
+    CONSTRAINT "items_itemPriceId_fkey" FOREIGN KEY ("itemPriceId") REFERENCES "item_price" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "items_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "items_addedById_fkey" FOREIGN KEY ("addedById") REFERENCES "user" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "items_pledgedById_fkey" FOREIGN KEY ("pledgedById") REFERENCES "user" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "items_publicPledgedById_fkey" FOREIGN KEY ("publicPledgedById") REFERENCES "system_user" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "items_groupId_fkey" FOREIGN KEY ("groupId") REFERENCES "group" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_items" ("addedById", "approved", "displayOrder", "groupId", "id", "imageUrl", "name", "note", "pledgedById", "price", "publicPledgedById", "purchased", "url", "userId") SELECT "addedById", "approved", "displayOrder", "groupId", "id", "imageUrl", "name", "note", "pledgedById", "price", "publicPledgedById", "purchased", "url", "userId" FROM "items";
+DROP TABLE "items";
+ALTER TABLE "new_items" RENAME TO "items";
+CREATE UNIQUE INDEX "items_id_key" ON "items"("id");
+CREATE INDEX "items_userId_idx" ON "items"("userId");
+CREATE INDEX "items_pledgedById_idx" ON "items"("pledgedById");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "item_price_id_key" ON "item_price"("id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -85,6 +85,8 @@ model Item {
     id                Int         @id @unique @default(autoincrement())
     name              String
     price             String?
+    itemPriceId       String?
+    itemPrice         ItemPrice?  @relation(fields: [itemPriceId], references: [id], onDelete: SetNull)
     url               String?
     note              String?
     imageUrl          String?
@@ -105,6 +107,15 @@ model Item {
     @@index([userId])
     @@index([pledgedById])
     @@map("items")
+}
+
+model ItemPrice {
+    id       String @id @unique @default(uuid())
+    value    Int
+    currency String
+    Item     Item[]
+
+    @@map("item_price")
 }
 
 model PasswordReset {

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -128,11 +128,7 @@ const patchPrice = async () => {
         if (!priceWithoutSymbols) {
             return;
         }
-        // if (/^\d+$/.test(priceWithoutSymbols)) {
-        //     // price is already digit
-        //     console.log("Price is already an integer value");
-        //     newPriceValue = parseInt(priceWithoutSymbols);
-        // } else
+
         if (commaGroupSepRegex.test(priceWithoutSymbols)) {
             // price is a number with comma as the group separator
             console.log("Price detected as using group separator ',' and decimal separator '.'");

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -88,9 +88,110 @@ const groups = async () => {
     }
 };
 
+const symbolToCurrencyMap = {
+    $: "USD",
+    "€": "EUR",
+    "£": "GBP",
+    "¥": "JPY"
+};
+
+const patchPrice = async () => {
+    console.log("Patching item price model");
+    const itemsWithPrice = await prisma.item.findMany({
+        where: {
+            price: {
+                not: null
+            },
+            itemPriceId: null
+        }
+    });
+
+    console.log("%d items to update", itemsWithPrice.length);
+    itemsWithPrice.forEach(async (item) => {
+        console.log("Patching item %s with price %s", item.name, item.price);
+        const commaGroupSepRegex = /^(\d{0,3}\\,\d{3}){0,}\d{0,}\.?\d{0,2}$/g;
+        const dotGroupSepRegex = /^(\d{0,3}\.\d{3}){0,}\d{0,},?\d{0,2}$/g;
+
+        const price = item.price;
+        const priceWithoutSymbols = /[\d\\.\\,]+/g.exec(price)?.[0]?.trim();
+        const symbol = /[^\\,\\.\d\w\s]/g.exec(price)?.[0];
+        let currency;
+        let newPriceValue;
+        if (symbol && symbolToCurrencyMap[symbol]) {
+            currency = symbolToCurrencyMap[symbol];
+            console.log("Detected currency as %s", currency);
+        } else {
+            currency = process.env.DEFAULT_CURRENCY || "USD";
+            console.log("No currency detected, defaulting to %s", currency);
+        }
+
+        if (!priceWithoutSymbols) {
+            return;
+        }
+        // if (/^\d+$/.test(priceWithoutSymbols)) {
+        //     // price is already digit
+        //     console.log("Price is already an integer value");
+        //     newPriceValue = parseInt(priceWithoutSymbols);
+        // } else
+        if (commaGroupSepRegex.test(priceWithoutSymbols)) {
+            // price is a number with comma as the group separator
+            console.log("Price detected as using group separator ',' and decimal separator '.'");
+            const priceWithoutSep = priceWithoutSymbols.replace(",", "");
+            console.log("price without separator: %s", priceWithoutSep);
+            if (priceWithoutSep.includes(".")) {
+                // has decimal value
+                const floatVal = parseFloat(priceWithoutSep);
+                console.log("float value: %s", floatVal);
+                newPriceValue = floatVal * 100;
+            } else {
+                newPriceValue = parseInt(priceWithoutSep) * 100;
+            }
+        }
+        if (dotGroupSepRegex.test(priceWithoutSymbols)) {
+            // price is a number with a dot as the group seperator
+            console.log("Price detected as using group separator '.' and decimal separator ','");
+            const priceWithoutSep = priceWithoutSymbols.replace(".", "");
+            if (priceWithoutSep.includes(",")) {
+                // has decimal value
+                const floatVal = parseFloat(priceWithoutSep.replace(",", "."));
+                newPriceValue = floatVal * 100;
+            } else {
+                newPriceValue = parseInt(priceWithoutSep) * 100;
+            }
+        }
+
+        if (!newPriceValue) {
+            console.log("Unable to determine price value\n");
+            return;
+        } else {
+            console.log("New price value: %s\n", newPriceValue);
+        }
+
+        try {
+            await prisma.item.update({
+                where: {
+                    id: item.id
+                },
+                data: {
+                    itemPrice: {
+                        create: {
+                            currency,
+                            value: newPriceValue
+                        }
+                    }
+                }
+            });
+        } catch (e) {
+            console.warn("Unable to update item with new price model", e);
+        }
+    });
+    console.log("Finished patching item price model");
+};
+
 const main = async () => {
     await roles();
     await groups();
+    await patchPrice();
 };
 
 main()

--- a/src/lib/components/CurrencyInput.svelte
+++ b/src/lib/components/CurrencyInput.svelte
@@ -29,6 +29,7 @@
         return new Intl.NumberFormat(locale, {
             currency: currency,
             style: "currency",
+            currencyDisplay: "narrowSymbol",
             maximumFractionDigits: maximumFractionDigits || 0,
             minimumFractionDigits: minimumFractionDigits || 0
         }).format(value);
@@ -162,7 +163,7 @@
     $: isPositive = value > 0;
     $: isZero = !isNegative && !isPositive;
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    $: value, setFormattedValue();
+    $: value, currency, setFormattedValue();
 </script>
 
 <div class="border-surface-400-500-token border-r focus:border-surface-400-500-token">

--- a/src/lib/components/CurrencyInput.svelte
+++ b/src/lib/components/CurrencyInput.svelte
@@ -1,0 +1,186 @@
+<!-- Original Source: https://github.com/fmaclen/svelte-currency-input -->
+<script lang="ts">
+    import { getFormatter } from "$lib/price-formatter";
+    import { onMount } from "svelte";
+
+    const DEFAULT_LOCALE = "en-US";
+    const DEFAULT_CURRENCY = "USD";
+    const DEFAULT_VALUE = 0;
+    const DEFAULT_FRACTION_DIGITS = 2;
+
+    type Callback = (value: number) => any;
+
+    export let value: number = DEFAULT_VALUE;
+    export let locale: string = DEFAULT_LOCALE;
+    export let currency: string = DEFAULT_CURRENCY;
+    export let name: string;
+    export let id: string;
+    export let required: boolean = false;
+    export let disabled: boolean = false;
+    export let placeholder: string | number | null = DEFAULT_VALUE;
+    export let autocomplete: string | null | undefined = undefined;
+    export let isNegativeAllowed: boolean = true;
+    export let isZeroNullish: boolean = false;
+    export let fractionDigits: number = DEFAULT_FRACTION_DIGITS;
+    export let onValueChange: Callback = () => {};
+
+    // Formats value as: e.g. $1,523.00 | -$1,523.00
+    const formatCurrency = (value: number, maximumFractionDigits?: number, minimumFractionDigits?: number) => {
+        return new Intl.NumberFormat(locale, {
+            currency: currency,
+            style: "currency",
+            maximumFractionDigits: maximumFractionDigits || 0,
+            minimumFractionDigits: minimumFractionDigits || 0
+        }).format(value);
+    };
+
+    // Checks if the key pressed is allowed
+    const handleKeyDown = (event: KeyboardEvent) => {
+        const isDeletion = event.key === "Backspace" || event.key === "Delete";
+        const isModifier = event.metaKey || event.altKey || event.ctrlKey;
+        const isArrowKey = event.key === "ArrowLeft" || event.key === "ArrowRight";
+        const isTab = event.key === "Tab";
+        const isInvalidCharacter = !/^\d|,|\.|-$/g.test(event.key); // Keys that are not a digit, comma, period or minus sign
+
+        // If there is already a decimal point, don't allow more than one
+        const isPunctuationDuplicated = () => {
+            if (event.key !== "," && event.key !== ".") return false; // Is `false` because it's not a punctuation key
+            if (isDecimalComma) return formattedValue.split(",").length >= 2;
+            if (!isDecimalComma) return formattedValue.split(".").length >= 2;
+            return false;
+        };
+
+        if (isPunctuationDuplicated() || (!isDeletion && !isModifier && !isArrowKey && isInvalidCharacter && !isTab)) {
+            event.preventDefault();
+            return;
+        }
+    };
+
+    // Formats the value when the input loses focus and sets the correct number of
+    // fraction digits when the value is zero
+    const handleOnBlur = () => setFormattedValue();
+
+    let dom: Document;
+    let inputElement: HTMLInputElement;
+
+    onMount(() => {
+        // Set the document object as a variable so we know the page has mounted
+        dom = document;
+
+        // Set the correct fraction digits when the value is zero on initial load
+        setFormattedValue();
+    });
+
+    const currencyFormatter = getFormatter(currency, locale);
+    const options = currencyFormatter.resolvedOptions();
+    const parts = currencyFormatter.formatToParts(1.1);
+    const currencyDecimal = parts.find((part) => part.type === "decimal")?.value || "."; // '.' or ','
+    const isDecimalComma = currencyDecimal === ",";
+    const currencySymbol = parts.find((part) => part.type === "currency")?.value;
+
+    // Updates `value` by stripping away the currency formatting
+    const setUnformattedValue = (event?: KeyboardEvent) => {
+        if (event) {
+            // Don't format if the user is typing a `currencyDecimal` point
+            if (event.key === currencyDecimal) return;
+
+            // Don't format if `formattedValue` is ['$', '-$', "-"]
+            const ignoreSymbols = [currencySymbol, `-${currencySymbol}`, "-"];
+            const strippedUnformattedValue = formattedValue.replace(" ", "");
+            if (ignoreSymbols.includes(strippedUnformattedValue)) return;
+
+            // Reverse the value when minus is pressed
+            if (isNegativeAllowed && event.key === "-") value = value * -1;
+        }
+
+        // Remove all characters that arent: numbers, commas, periods (or minus signs if `isNegativeAllowed`)
+        let unformattedValue = isNegativeAllowed
+            ? formattedValue.replace(/[^0-9,.-]/g, "")
+            : formattedValue.replace(/[^0-9,.]/g, "");
+
+        // Finally set the value
+        if (Number.isNaN(parseFloat(unformattedValue))) {
+            value = 0;
+        } else {
+            // The order of the following operations is *critical*
+            unformattedValue = unformattedValue.replace(isDecimalComma ? /\./g : /,/g, ""); // Remove all group symbols
+            if (isDecimalComma) unformattedValue = unformattedValue.replace(",", "."); // If the decimal point is a comma, replace it with a period
+
+            // If the zero-key has been pressed
+            // and if the current `value` is the same as the `value` before the key-press
+            // formatting may need to be done (Issue #30)
+            const previousValue = value;
+            value = parseFloat(unformattedValue);
+
+            if (event && previousValue === value) {
+                // Do the formatting if the number of digits after the decimal point exceeds `fractionDigits`
+                if (unformattedValue.includes(".") && unformattedValue.split(".")[1].length > fractionDigits) {
+                    setFormattedValue();
+                }
+            }
+        }
+    };
+
+    const setFormattedValue = () => {
+        // Do nothing because the page hasn't mounted yet
+        if (!dom) return;
+
+        // Previous caret position
+        const startCaretPosition = inputElement?.selectionStart || 0;
+        const previousFormattedValueLength = formattedValue.length;
+
+        // Apply formatting to input
+        formattedValue =
+            isZero && !isZeroNullish
+                ? ""
+                : formatCurrency(value, fractionDigits, dom.activeElement === inputElement ? 0 : fractionDigits);
+
+        // Update `value` after formatting
+        setUnformattedValue();
+
+        let retries = 0;
+        while (previousFormattedValueLength === formattedValue.length && retries < 10) retries++;
+
+        if (previousFormattedValueLength !== formattedValue.length) {
+            const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
+            inputElement?.setSelectionRange(endCaretPosition, endCaretPosition);
+        }
+
+        // Run callback function when `value` changes
+        onValueChange(value);
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const handlePlaceholder = (placeholder: string | number | null, currency: string) => {
+        if (typeof placeholder === "number") return formatCurrency(placeholder, fractionDigits, fractionDigits);
+        if (placeholder === null) return "";
+        return placeholder;
+    };
+
+    let formattedValue = "";
+    $: isNegative = value < 0;
+    $: isPositive = value > 0;
+    $: isZero = !isNegative && !isPositive;
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    $: value, setFormattedValue();
+</script>
+
+<div class="border-surface-400-500-token border-r focus:border-surface-400-500-token">
+    <input {id} {name} {disabled} type="hidden" bind:value />
+    <input
+        bind:this={inputElement}
+        id={`formatted-${id}`}
+        name={`formatted-${name}`}
+        class="input"
+        {autocomplete}
+        {disabled}
+        inputmode={options.maximumFractionDigits || DEFAULT_FRACTION_DIGITS > 0 ? "decimal" : "numeric"}
+        placeholder={handlePlaceholder(placeholder, currency)}
+        required={required && !isZero}
+        type="text"
+        bind:value={formattedValue}
+        on:keydown={handleKeyDown}
+        on:keyup={setUnformattedValue}
+        on:blur={handleOnBlur}
+    />
+</div>

--- a/src/lib/components/CurrencyInput.svelte
+++ b/src/lib/components/CurrencyInput.svelte
@@ -1,42 +1,29 @@
-<!-- Original Source: https://github.com/fmaclen/svelte-currency-input -->
 <script lang="ts">
-    import { getFormatter } from "$lib/price-formatter";
+    import { getFormatter, getLocaleConfig } from "$lib/price-formatter";
+    import type { KeyboardEventHandler } from "svelte/elements";
     import { onMount } from "svelte";
 
-    const DEFAULT_LOCALE = "en-US";
-    const DEFAULT_CURRENCY = "USD";
-    const DEFAULT_VALUE = 0;
-    const DEFAULT_FRACTION_DIGITS = 2;
-
-    type Callback = (value: number) => any;
-
-    export let value: number = DEFAULT_VALUE;
-    export let locale: string = DEFAULT_LOCALE;
-    export let currency: string = DEFAULT_CURRENCY;
+    export let value: number | null = null;
+    export let locale: string = "en-US";
+    export let currency: string = "USD";
     export let name: string;
     export let id: string;
-    export let required: boolean = false;
     export let disabled: boolean = false;
-    export let placeholder: string | number | null = DEFAULT_VALUE;
-    export let autocomplete: string | null | undefined = undefined;
-    export let isNegativeAllowed: boolean = true;
-    export let isZeroNullish: boolean = false;
-    export let fractionDigits: number = DEFAULT_FRACTION_DIGITS;
-    export let onValueChange: Callback = () => {};
 
-    // Formats value as: e.g. $1,523.00 | -$1,523.00
-    const formatCurrency = (value: number, maximumFractionDigits?: number, minimumFractionDigits?: number) => {
-        return new Intl.NumberFormat(locale, {
-            currency: currency,
-            style: "currency",
-            currencyDisplay: "narrowSymbol",
-            maximumFractionDigits: maximumFractionDigits || 0,
-            minimumFractionDigits: minimumFractionDigits || 0
-        }).format(value);
-    };
+    let formatter = getFormatter(currency, locale);
+    let localeConfig = getLocaleConfig(formatter);
+    let maximumFractionDigits = formatter.resolvedOptions().maximumFractionDigits || 2;
+    let inputtedValue = value ? value.toString() : "";
+    let displayValue = inputtedValue;
+    let inputElement: HTMLInputElement | undefined;
+    let isMounted = false;
+
+    onMount(() => {
+        isMounted = true;
+    });
 
     // Checks if the key pressed is allowed
-    const handleKeyDown = (event: KeyboardEvent) => {
+    const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
         const isDeletion = event.key === "Backspace" || event.key === "Delete";
         const isModifier = event.metaKey || event.altKey || event.ctrlKey;
         const isArrowKey = event.key === "ArrowLeft" || event.key === "ArrowRight";
@@ -46,8 +33,7 @@
         // If there is already a decimal point, don't allow more than one
         const isPunctuationDuplicated = () => {
             if (event.key !== "," && event.key !== ".") return false; // Is `false` because it's not a punctuation key
-            if (isDecimalComma) return formattedValue.split(",").length >= 2;
-            if (!isDecimalComma) return formattedValue.split(".").length >= 2;
+            if (localeConfig.decimalSeparator) return displayValue.split(localeConfig.decimalSeparator).length > 1;
             return false;
         };
 
@@ -57,113 +43,35 @@
         }
     };
 
-    // Formats the value when the input loses focus and sets the correct number of
-    // fraction digits when the value is zero
-    const handleOnBlur = () => setFormattedValue();
-
-    let dom: Document;
-    let inputElement: HTMLInputElement;
-
-    onMount(() => {
-        // Set the document object as a variable so we know the page has mounted
-        dom = document;
-
-        // Set the correct fraction digits when the value is zero on initial load
-        setFormattedValue();
-    });
-
-    const currencyFormatter = getFormatter(currency, locale);
-    const options = currencyFormatter.resolvedOptions();
-    const parts = currencyFormatter.formatToParts(1.1);
-    const currencyDecimal = parts.find((part) => part.type === "decimal")?.value || "."; // '.' or ','
-    const isDecimalComma = currencyDecimal === ",";
-    const currencySymbol = parts.find((part) => part.type === "currency")?.value;
-
-    // Updates `value` by stripping away the currency formatting
-    const setUnformattedValue = (event?: KeyboardEvent) => {
-        if (event) {
-            // Don't format if the user is typing a `currencyDecimal` point
-            if (event.key === currencyDecimal) return;
-
-            // Don't format if `formattedValue` is ['$', '-$', "-"]
-            const ignoreSymbols = [currencySymbol, `-${currencySymbol}`, "-"];
-            const strippedUnformattedValue = formattedValue.replace(" ", "");
-            if (ignoreSymbols.includes(strippedUnformattedValue)) return;
-
-            // Reverse the value when minus is pressed
-            if (isNegativeAllowed && event.key === "-") value = value * -1;
+    const handleBlur = () => {
+        if (displayValue === "") {
+            value = null;
+            inputtedValue = "";
+            displayValue = "";
+            return;
         }
-
-        // Remove all characters that arent: numbers, commas, periods (or minus signs if `isNegativeAllowed`)
-        let unformattedValue = isNegativeAllowed
-            ? formattedValue.replace(/[^0-9,.-]/g, "")
-            : formattedValue.replace(/[^0-9,.]/g, "");
-
-        // Finally set the value
-        if (Number.isNaN(parseFloat(unformattedValue))) {
-            value = 0;
-        } else {
-            // The order of the following operations is *critical*
-            unformattedValue = unformattedValue.replace(isDecimalComma ? /\./g : /,/g, ""); // Remove all group symbols
-            if (isDecimalComma) unformattedValue = unformattedValue.replace(",", "."); // If the decimal point is a comma, replace it with a period
-
-            // If the zero-key has been pressed
-            // and if the current `value` is the same as the `value` before the key-press
-            // formatting may need to be done (Issue #30)
-            const previousValue = value;
-            value = parseFloat(unformattedValue);
-
-            if (event && previousValue === value) {
-                // Do the formatting if the number of digits after the decimal point exceeds `fractionDigits`
-                if (unformattedValue.includes(".") && unformattedValue.split(".")[1].length > fractionDigits) {
-                    setFormattedValue();
-                }
-            }
+        let stringValue = displayValue;
+        if (localeConfig.groupSeparator === ".") {
+            stringValue = stringValue.replace(".", "");
+        } else if (localeConfig.groupSeparator === ",") {
+            stringValue = stringValue.replace(",", "");
         }
+        if (localeConfig.decimalSeparator === ",") {
+            stringValue = stringValue.replace(",", ".");
+        }
+        value = parseFloat(stringValue);
+        inputtedValue = displayValue;
+        displayValue = formatter.format(value);
     };
 
-    const setFormattedValue = () => {
-        // Do nothing because the page hasn't mounted yet
-        if (!dom) return;
-
-        // Previous caret position
-        const startCaretPosition = inputElement?.selectionStart || 0;
-        const previousFormattedValueLength = formattedValue.length;
-
-        // Apply formatting to input
-        formattedValue =
-            isZero && !isZeroNullish
-                ? ""
-                : formatCurrency(value, fractionDigits, dom.activeElement === inputElement ? 0 : fractionDigits);
-
-        // Update `value` after formatting
-        setUnformattedValue();
-
-        let retries = 0;
-        while (previousFormattedValueLength === formattedValue.length && retries < 10) retries++;
-
-        if (previousFormattedValueLength !== formattedValue.length) {
-            const endCaretPosition = startCaretPosition + formattedValue.length - previousFormattedValueLength;
-            inputElement?.setSelectionRange(endCaretPosition, endCaretPosition);
-        }
-
-        // Run callback function when `value` changes
-        onValueChange(value);
+    const handleFocus = () => {
+        displayValue = inputtedValue;
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const handlePlaceholder = (placeholder: string | number | null, currency: string) => {
-        if (typeof placeholder === "number") return formatCurrency(placeholder, fractionDigits, fractionDigits);
-        if (placeholder === null) return "";
-        return placeholder;
-    };
-
-    let formattedValue = "";
-    $: isNegative = value < 0;
-    $: isPositive = value > 0;
-    $: isZero = !isNegative && !isPositive;
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    $: value, currency, setFormattedValue();
+    $: formatter = getFormatter(currency, locale);
+    $: {
+        if (isMounted && document.activeElement !== inputElement && value) displayValue = formatter.format(value);
+    }
 </script>
 
 <div class="border-surface-400-500-token border-r focus:border-surface-400-500-token">
@@ -173,15 +81,14 @@
         id={`formatted-${id}`}
         name={`formatted-${name}`}
         class="input"
-        {autocomplete}
+        autocomplete="off"
         {disabled}
-        inputmode={options.maximumFractionDigits || DEFAULT_FRACTION_DIGITS > 0 ? "decimal" : "numeric"}
-        placeholder={handlePlaceholder(placeholder, currency)}
-        required={required && !isZero}
+        inputmode={maximumFractionDigits > 0 ? "decimal" : "numeric"}
+        placeholder={formatter.format(0)}
         type="text"
-        bind:value={formattedValue}
+        bind:value={displayValue}
         on:keydown={handleKeyDown}
-        on:keyup={setUnformattedValue}
-        on:blur={handleOnBlur}
+        on:blur={handleBlur}
+        on:focus={handleFocus}
     />
 </div>

--- a/src/lib/components/wishlists/ItemCard/ItemCard.svelte
+++ b/src/lib/components/wishlists/ItemCard/ItemCard.svelte
@@ -12,6 +12,7 @@
         pledgedBy: PartialUser | null;
         publicPledgedBy?: PublicUser | null;
         user: PartialUser | null;
+        itemPrice: ItemPrice | null;
     };
 </script>
 
@@ -23,13 +24,15 @@
         type DrawerSettings,
         type ModalSettings
     } from "@skeletonlabs/skeleton";
-    import type { Item } from "@prisma/client";
+    import type { Item, ItemPrice } from "@prisma/client";
     import { ItemAPI } from "$lib/api/items";
     import ApprovalButtons from "./ApprovalButtons.svelte";
     import ClaimButtons from "./ClaimButtons.svelte";
     import { invalidateAll } from "$app/navigation";
     import type { ItemVoidFunction } from "./ReorderButtons.svelte";
     import ReorderButtons from "./ReorderButtons.svelte";
+    import { formatPrice } from "$lib/price-formatter";
+    import { onMount } from "svelte";
 
     export let item: FullItem;
     export let user: (PartialUser & { id: string }) | undefined = undefined;
@@ -46,6 +49,7 @@
 
     let imageUrl: string;
     const itemAPI = new ItemAPI(item.id);
+    let locale: string | undefined;
 
     $: if (item.imageUrl) {
         try {
@@ -55,6 +59,14 @@
             imageUrl = `/api/assets/${item.imageUrl}`;
         }
     }
+
+    onMount(() => {
+        if (navigator.languages?.length > 0) {
+            locale = navigator.languages[0];
+        } else {
+            locale = navigator.language;
+        }
+    });
 
     const triggerErrorToast = () => {
         toastStore.trigger({
@@ -170,6 +182,7 @@
             item,
             showFor,
             user,
+            locale,
             showClaimedName,
             onPublicList,
             handleClaim,
@@ -213,7 +226,7 @@
 
         <div class="flex flex-col">
             {#if item.price}
-                <span class="text-lg font-semibold">{item.price}</span>
+                <span class="text-lg font-semibold">{formatPrice(item, locale)}</span>
             {/if}
 
             <span class="text-base md:text-lg">

--- a/src/lib/components/wishlists/ItemCard/ItemCard.svelte
+++ b/src/lib/components/wishlists/ItemCard/ItemCard.svelte
@@ -225,7 +225,7 @@
         {/if}
 
         <div class="flex flex-col">
-            {#if item.price}
+            {#if item.price || item.itemPrice}
                 <span class="text-lg font-semibold">{formatPrice(item, locale)}</span>
             {/if}
 

--- a/src/lib/components/wishlists/ItemDrawer.svelte
+++ b/src/lib/components/wishlists/ItemDrawer.svelte
@@ -3,10 +3,12 @@
     import type { FullItem, PartialUser } from "./ItemCard/ItemCard.svelte";
     import ClaimButtons from "./ItemCard/ClaimButtons.svelte";
     import ApprovalButtons from "./ItemCard/ApprovalButtons.svelte";
+    import { formatPrice } from "$lib/price-formatter";
 
     const drawerStore = getDrawerStore();
     const item: FullItem = $drawerStore.meta.item;
     const user: PartialUser | undefined = $drawerStore.meta.user;
+    const locale: string | undefined = $drawerStore.meta.locale;
     const showFor: boolean = $drawerStore.meta.showFor;
     const showName: boolean = $drawerStore.meta.showName;
     const onPublicList: boolean = $drawerStore.meta.onPublicList;
@@ -30,7 +32,7 @@
     </div>
     <div class="flex flex-row space-x-2 text-base md:text-lg">
         {#if item.price}
-            <span class="font-semibold">{item.price}</span>
+            <span class="font-semibold">{formatPrice(item, locale)}</span>
             <span>·</span>
         {/if}
 

--- a/src/lib/components/wishlists/ItemDrawer.svelte
+++ b/src/lib/components/wishlists/ItemDrawer.svelte
@@ -47,7 +47,7 @@
         {/if}
     </div>
     <div class="flex flex-row space-x-2 text-base md:text-lg">
-        {#if item.price}
+        {#if item.price || item.itemPrice}
             <span class="font-semibold">{formatPrice(item, locale)}</span>
             <span>·</span>
         {/if}

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -87,6 +87,7 @@
         }
         try {
             Intl.NumberFormat(undefined, { style: "currency", currency });
+            userCurrency = currency.toUpperCase();
         } catch {
             userCurrency = previousCurrency;
             toastStore.trigger({
@@ -177,7 +178,7 @@
             <CurrencyInput id="price" name="price" currency={previousCurrency} {locale} bind:value={price} />
             <input id="currency" name="currency" type="hidden" bind:value={userCurrency} />
             <input
-                class="border-surface-400-500-token w-[8ch] border-l focus:border-surface-400-500-token"
+                class="border-surface-400-500-token w-[8ch] border-l uppercase focus:border-surface-400-500-token"
                 maxlength="3"
                 on:change={(e) => validateCurrency(e.currentTarget.value)}
                 bind:value={userCurrency}

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -30,14 +30,6 @@
         }
     });
 
-    const formatPrice = (price: number | null, currency: string | null) => {
-        if (!price) return null;
-        return Intl.NumberFormat(undefined, {
-            style: "currency",
-            currency: currency ? currency : env.PUBLIC_DEFAULT_CURRENCY
-        }).format(price);
-    };
-
     const extractUrl = (url: string) => {
         const urlRegex = /(https?):\/\/[^\s/$.?#].[^\s]*/;
         const matches = url.match(urlRegex);
@@ -66,7 +58,16 @@
                 data.url = productData.url ? productData.url : url;
                 data.name = productData.name ? productData.name : productData.title || "";
                 data.imageUrl = productData.image;
-                data.price = formatPrice(productData.price, productData.currency);
+                if (productData.price) {
+                    data.itemPrice = {
+                        id: "temp-id",
+                        currency: productData.currency || env.PUBLIC_DEFAULT_CURRENCY,
+                        value: productData.price
+                    };
+                    price = data.itemPrice.value;
+                    userCurrency = data.itemPrice.currency;
+                    previousCurrency = userCurrency;
+                }
             } else {
                 triggerToast();
             }
@@ -180,14 +181,14 @@
                 {locale}
                 bind:value={price}
             />
+            <input id="currency" name="currency" type="hidden" bind:value={userCurrency} />
             <input
-                class="border-surface-400-500-token w-[6ch] border-l focus:border-surface-400-500-token"
+                class="border-surface-400-500-token w-[8ch] border-l focus:border-surface-400-500-token"
                 maxlength="3"
                 on:change={(e) => validateCurrency(e.currentTarget.value)}
                 bind:value={userCurrency}
             />
         </div>
-        <pre>{price}</pre>
     </label>
 
     <label class="col-span-1 md:col-span-2" for="image">

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -9,7 +9,7 @@
     import CurrencyInput from "../CurrencyInput.svelte";
 
     export let data: Partial<Item> & {
-        itemPrice?: ItemPrice;
+        itemPrice?: ItemPrice | null;
     };
     export let buttonText: string;
 

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -5,8 +5,8 @@
     import { env } from "$env/dynamic/public";
     import { getToastStore } from "@skeletonlabs/skeleton";
     import { onMount } from "svelte";
-    import CurrencyInput from "../CurrencyInput.svelte";
     import { getPriceValue } from "$lib/price-formatter";
+    import CurrencyInput from "../CurrencyInput.svelte";
 
     export let data: Partial<Item> & {
         itemPrice?: ItemPrice;
@@ -173,14 +173,7 @@
             <div class="input-group-shim">
                 <iconify-icon icon="ion:cash"></iconify-icon>
             </div>
-            <CurrencyInput
-                id="price"
-                name="price"
-                autocomplete="off"
-                currency={previousCurrency}
-                {locale}
-                bind:value={price}
-            />
+            <CurrencyInput id="price" name="price" currency={previousCurrency} {locale} bind:value={price} />
             <input id="currency" name="currency" type="hidden" bind:value={userCurrency} />
             <input
                 class="border-surface-400-500-token w-[8ch] border-l focus:border-surface-400-500-token"

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -19,7 +19,8 @@
     const toastStore = getToastStore();
     let locale: string | undefined;
     let price: number = getPriceValue(data);
-    let userCurrency: string = data.itemPrice?.currency || env.PUBLIC_DEFAULT_CURRENCY;
+    const defaultCurrency = env.PUBLIC_DEFAULT_CURRENCY || "USD";
+    let userCurrency: string = data.itemPrice?.currency || defaultCurrency;
     let previousCurrency = userCurrency;
 
     onMount(() => {
@@ -61,7 +62,7 @@
                 if (productData.price) {
                     data.itemPrice = {
                         id: "temp-id",
-                        currency: productData.currency || env.PUBLIC_DEFAULT_CURRENCY,
+                        currency: productData.currency || defaultCurrency,
                         value: productData.price
                     };
                     price = data.itemPrice.value;

--- a/src/lib/price-formatter.ts
+++ b/src/lib/price-formatter.ts
@@ -6,6 +6,14 @@ type ItemWithPrice = {
     itemPrice?: ItemPrice | null;
 };
 
+export type LocaleConfig = {
+    currencySymbol: string;
+    groupSeparator: string;
+    decimalSeparator: string;
+    prefix: string;
+    suffix: string;
+};
+
 const getMaximumFractionDigits = (currency: string) => {
     return getFormatter(currency).resolvedOptions().maximumFractionDigits || 2;
 };
@@ -45,4 +53,32 @@ export const getPriceValue = (item: ItemWithPrice) => {
 export const getMinorUnits = (value: number, currency: string) => {
     const maxFracDigits = getMaximumFractionDigits(currency);
     return value * Math.pow(10, maxFracDigits);
+};
+
+const defaultConfig: LocaleConfig = {
+    currencySymbol: "",
+    groupSeparator: "",
+    decimalSeparator: "",
+    prefix: "",
+    suffix: ""
+};
+
+export const getLocaleConfig = (formatter: Intl.NumberFormat) => {
+    return formatter.formatToParts(1000.1).reduce((prev, curr, i): LocaleConfig => {
+        if (curr.type === "currency") {
+            if (i === 0) {
+                return { ...prev, currencySymbol: curr.value, prefix: curr.value };
+            } else {
+                return { ...prev, currencySymbol: curr.value, suffix: curr.value };
+            }
+        }
+        if (curr.type === "group") {
+            return { ...prev, groupSeparator: curr.value };
+        }
+        if (curr.type === "decimal") {
+            return { ...prev, decimalSeparator: curr.value };
+        }
+
+        return prev;
+    }, defaultConfig);
 };

--- a/src/lib/price-formatter.ts
+++ b/src/lib/price-formatter.ts
@@ -6,6 +6,10 @@ type ItemWithPrice = {
     itemPrice?: ItemPrice | null;
 };
 
+const getMaximumFractionDigits = (currency: string) => {
+    return getFormatter(currency).resolvedOptions().maximumFractionDigits || 2;
+};
+
 export const getFormatter = (currency: string | null, locale: string | undefined = undefined) => {
     return Intl.NumberFormat(locale, {
         style: "currency",
@@ -20,7 +24,7 @@ export const formatPrice = (item: ItemWithPrice, locale: string | undefined = un
     }
 
     const formatter = getFormatter(item.itemPrice.currency, locale);
-    const maxFracDigits = formatter.resolvedOptions().maximumFractionDigits || 2;
+    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency);
 
     const value = item.itemPrice.value / Math.pow(10, maxFracDigits);
     return formatter.format(value);
@@ -34,6 +38,11 @@ export const getPriceValue = (item: ItemWithPrice) => {
     if (!item.itemPrice) {
         return 0;
     }
-    const maxFracDigits = getFormatter(item.itemPrice.currency).resolvedOptions().maximumFractionDigits || 2;
+    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency);
     return item.itemPrice.value / Math.pow(10, maxFracDigits);
+};
+
+export const getMinorUnits = (value: number, currency: string) => {
+    const maxFracDigits = getMaximumFractionDigits(currency);
+    return value * Math.pow(10, maxFracDigits);
 };

--- a/src/lib/price-formatter.ts
+++ b/src/lib/price-formatter.ts
@@ -1,0 +1,39 @@
+import { env } from "$env/dynamic/public";
+import type { ItemPrice } from "@prisma/client";
+
+type ItemWithPrice = {
+    price?: string | null;
+    itemPrice?: ItemPrice | null;
+};
+
+export const getFormatter = (currency: string | null, locale: string | undefined = undefined) => {
+    return Intl.NumberFormat(locale, {
+        style: "currency",
+        currency: currency || env.PUBLIC_DEFAULT_CURRENCY,
+        currencyDisplay: "narrowSymbol"
+    });
+};
+
+export const formatPrice = (item: ItemWithPrice, locale: string | undefined = undefined) => {
+    if (!item.itemPrice) {
+        return item.price;
+    }
+
+    const formatter = getFormatter(item.itemPrice.currency, locale);
+    const maxFracDigits = formatter.resolvedOptions().maximumFractionDigits || 2;
+
+    const value = item.itemPrice.value / Math.pow(10, maxFracDigits);
+    return formatter.format(value);
+};
+
+export const formatNumberAsPrice = (price: number, locale: string | undefined = undefined) => {
+    return getFormatter(null, locale).format(price);
+};
+
+export const getPriceValue = (item: ItemWithPrice) => {
+    if (!item.itemPrice) {
+        return 0;
+    }
+    const maxFracDigits = getFormatter(item.itemPrice.currency).resolvedOptions().maximumFractionDigits || 2;
+    return item.itemPrice.value / Math.pow(10, maxFracDigits);
+};

--- a/src/lib/server/api-common.ts
+++ b/src/lib/server/api-common.ts
@@ -1,3 +1,4 @@
+import { getMinorUnits } from "$lib/price-formatter";
 import type { Prisma } from "@prisma/client";
 
 export const patchItem = (body: Record<string, unknown>) => {
@@ -7,7 +8,6 @@ export const patchItem = (body: Record<string, unknown>) => {
     let deleteOldImage = false;
 
     if (body.name && typeof body.name === "string") data.name = body.name;
-    if (body.price && typeof body.price === "string") data.price = body.price;
     if (body.url && typeof body.url === "string") data.url = body.url;
     if (body.note && typeof body.note === "string") data.note = body.note;
     if (body.displayOrder !== null && typeof body.displayOrder === "number")
@@ -15,6 +15,15 @@ export const patchItem = (body: Record<string, unknown>) => {
     if (body.image_url && typeof body.image_url === "string") {
         data.imageUrl = body.image_url;
         deleteOldImage = true;
+    }
+    if (body.price && typeof body.price === "number" && body.currency && typeof body.currency === "string") {
+        data.itemPrice = {
+            create: {
+                value: getMinorUnits(body.price, body.currency),
+                currency: body.currency
+            },
+            delete: true
+        };
     }
     if (body.pledgedById && typeof body.pledgedById === "string") {
         if (body.pledgedById === "0") {

--- a/src/routes/api/items/+server.ts
+++ b/src/routes/api/items/+server.ts
@@ -124,7 +124,8 @@ export const PATCH: RequestHandler = async ({ locals, request }) => {
                         username: true,
                         name: true
                     }
-                }
+                },
+                itemPrice: true
             },
             data: patch.data as Prisma.ItemUpdateInput
         });

--- a/src/routes/api/items/[itemId]/+server.ts
+++ b/src/routes/api/items/[itemId]/+server.ts
@@ -148,7 +148,8 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
                         username: true,
                         name: true
                     }
-                }
+                },
+                itemPrice: true
             },
             data: data as Prisma.ItemUpdateInput
         });

--- a/src/routes/claims/+page.server.ts
+++ b/src/routes/claims/+page.server.ts
@@ -36,7 +36,8 @@ export const load: PageServerLoad = async ({ locals }) => {
                     username: true,
                     name: true
                 }
-            }
+            },
+            itemPrice: true
         }
     });
 

--- a/src/routes/lists/[id]/+page.server.ts
+++ b/src/routes/lists/[id]/+page.server.ts
@@ -51,7 +51,8 @@ export const load = (async ({ params }) => {
                     username: true,
                     name: true
                 }
-            }
+            },
+            itemPrice: true
         }
     });
 

--- a/src/routes/wishlists/[username]/+page.server.ts
+++ b/src/routes/wishlists/[username]/+page.server.ts
@@ -59,7 +59,13 @@ export const load: PageServerLoad = async ({ locals, params, url, depends }) => 
     const sort = url.searchParams.get("sort");
     const direction = url.searchParams.get("dir");
     if (sort === "price" && direction && (direction === "asc" || direction === "desc")) {
-        orderBy = [{ price: direction }];
+        orderBy = [
+            {
+                itemPrice: {
+                    value: direction
+                }
+            }
+        ];
     } else {
         orderBy = [
             {
@@ -102,12 +108,7 @@ export const load: PageServerLoad = async ({ locals, params, url, depends }) => 
                     name: true
                 }
             },
-            itemPrice: {
-                select: {
-                    value: true,
-                    currency: true
-                }
-            }
+            itemPrice: true
         }
     });
 

--- a/src/routes/wishlists/[username]/+page.server.ts
+++ b/src/routes/wishlists/[username]/+page.server.ts
@@ -124,6 +124,11 @@ export const load: PageServerLoad = async ({ locals, params, url, depends }) => 
 
     const [wishlistItems, listOwner] = await Promise.all([wishlistItemsQuery, listOwnerQuery]);
 
+    if (sort === "price" && direction === "asc") {
+        // need to re-sort when descending since Prisma can't order with nulls last
+        wishlistItems.sort((a, b) => (a.itemPrice?.value ?? Infinity) - (b.itemPrice?.value ?? Infinity));
+    }
+
     depends("data:items");
     return {
         user: locals.user,

--- a/src/routes/wishlists/[username]/+page.server.ts
+++ b/src/routes/wishlists/[username]/+page.server.ts
@@ -101,6 +101,12 @@ export const load: PageServerLoad = async ({ locals, params, url, depends }) => 
                     username: true,
                     name: true
                 }
+            },
+            itemPrice: {
+                select: {
+                    value: true,
+                    currency: true
+                }
             }
         }
     });

--- a/src/routes/wishlists/[username]/edit/[itemId]/+page.server.ts
+++ b/src/routes/wishlists/[username]/edit/[itemId]/+page.server.ts
@@ -6,6 +6,7 @@ import { getActiveMembership } from "$lib/server/group-membership";
 import { createImage, tryDeleteImage } from "$lib/server/image-util";
 import { itemEmitter } from "$lib/server/events/emitters";
 import { SSEvents } from "$lib/schema";
+import { getMinorUnits } from "$lib/price-formatter";
 
 export const load: PageServerLoad = async ({ locals, params }) => {
     if (!locals.user) {
@@ -66,6 +67,7 @@ export const actions: Actions = {
         const image = form.get("image") as File;
         const name = form.get("name") as string;
         const price = form.get("price") as string;
+        const currency = form.get("currency") as string;
         const note = form.get("note") as string;
 
         // check for empty values
@@ -81,16 +83,28 @@ export const actions: Actions = {
             }
         });
 
+        let itemPriceId = null;
+        if (price && currency) {
+            await client.itemPrice
+                .create({
+                    data: {
+                        value: getMinorUnits(parseFloat(price), currency),
+                        currency
+                    }
+                })
+                .then((itemPrice) => (itemPriceId = itemPrice.id));
+        }
+
         const updatedItem = await client.item.update({
             where: {
                 id: parseInt(params.itemId)
             },
             data: {
                 name,
-                price,
                 url,
                 imageUrl: filename || imageUrl,
-                note
+                note,
+                itemPriceId
             },
             include: {
                 addedBy: {
@@ -110,9 +124,18 @@ export const actions: Actions = {
                         username: true,
                         name: true
                     }
-                }
+                },
+                itemPrice: true
             }
         });
+
+        if (item.itemPriceId !== null && item.itemPriceId !== itemPriceId) {
+            await client.itemPrice.delete({
+                where: {
+                    id: item.itemPriceId
+                }
+            });
+        }
 
         itemEmitter.emit(SSEvents.item.update, updatedItem);
 

--- a/src/routes/wishlists/[username]/edit/[itemId]/+page.server.ts
+++ b/src/routes/wishlists/[username]/edit/[itemId]/+page.server.ts
@@ -36,7 +36,8 @@ export const load: PageServerLoad = async ({ locals, params }) => {
                     select: {
                         username: true
                     }
-                }
+                },
+                itemPrice: true
             }
         });
     } catch {


### PR DESCRIPTION
Refactor the item price model to store prices as numbers instead of strings. This will allow for better localization and the ability to properly sort items by prices.
Important Note: This may break some prices when editing an existing item. Best effort is put into the migration, but if the current price cannot be parsed, then the new price model will not be migrated. Item cards will continue to show the old price for backwards compatibility.

Fixes #135 