### PR TITLE
Add basic bookmarklet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ You configure this using environment variables.
 
 `HEADER_EMAIL`: The name of the headers that contains the email of the user
 
+## Add items using a Bookmarklet
+
+Wishlist supports adding items via a bookmarklet. Whenever you're on a product page that you want to add to Wishlist, you can click on your bookmarklet to open Wishlist in a new tab and instantly start creating a new item.
+
+To create a bookmarklet, paste the following code into a [bookmarklet generator site](). Change the two variables that have comments, generate, and save the bookmarklet.
+
+```js
+var url = document.URL.endsWith('/') ?
+    document.URL.slice(0, -1) :
+    document.URL;
+var wishlist = "http://localhost:5173"; // host of your wishlist instance
+var listId = "xyz" // this is the id of the list you want to add the item to. You can get the id of the list from the URL
+
+if (wishlist.slice(-1) === "/") {
+    wishlist = wishlist.slice(0, -1)
+}
+var dest = wishlist + "/lists/" + listId + "/create-item?productUrl=" + url;
+window.open(dest, "_blank");
+```
+
 ## Contributing
 
 Code contributions are always welcome! If you have something in mind that you would like to work on, please open an issue or comment on an existing issue indicating your interest to make sure someone else isn't already working on it and to discuss any implementation details. Open a PR when you feel that it is ready. You can also open a draft PR as soon as you start work to help track progress.

--- a/README.md
+++ b/README.md
@@ -151,14 +151,12 @@ Wishlist supports adding items via a bookmarklet. Whenever you're on a product p
 To create a bookmarklet, paste the following code into a [bookmarklet generator site](). Change the two variables that have comments, generate, and save the bookmarklet.
 
 ```js
-var url = document.URL.endsWith('/') ?
-    document.URL.slice(0, -1) :
-    document.URL;
+var url = document.URL.endsWith("/") ? document.URL.slice(0, -1) : document.URL;
 var wishlist = "http://localhost:5173"; // host of your wishlist instance
-var listId = "xyz" // this is the id of the list you want to add the item to. You can get the id of the list from the URL
+var listId = "xyz"; // this is the id of the list you want to add the item to. You can get the id of the list from the URL
 
 if (wishlist.slice(-1) === "/") {
-    wishlist = wishlist.slice(0, -1)
+    wishlist = wishlist.slice(0, -1);
 }
 var dest = wishlist + "/lists/" + listId + "/create-item?productUrl=" + url;
 window.open(dest, "_blank");

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { page } from "$app/stores";
+    import { page } from "$app/state";
     import type { Item, ItemPrice } from "@prisma/client";
     import Backdrop from "$lib/components/Backdrop.svelte";
     import { env } from "$env/dynamic/public";
@@ -7,6 +7,7 @@
     import { getPriceValue } from "$lib/price-formatter";
     import CurrencyInput from "../CurrencyInput.svelte";
     import { t } from "svelte-i18n";
+    import { onMount } from "svelte";
 
     interface Props {
         data: Partial<Item> & {
@@ -18,7 +19,8 @@
     let { data = $bindable(), buttonText }: Props = $props();
 
     let productData = $state(data);
-    let form = $derived($page.form);
+    let form = $derived(page.form);
+    let url = $derived(page.url);
     let loading = $state(false);
     let urlFetched = $state(false);
     const toastStore = getToastStore();
@@ -88,6 +90,13 @@
             urlFetched = true;
         }
     };
+
+    onMount(async () => {
+        if (url.searchParams.has("productUrl")) {
+            productData.url = url.searchParams.get("productUrl");
+            await getInfo();
+        }
+    });
 </script>
 
 <div class="grid grid-cols-1 gap-4 md:grid-cols-6">

--- a/src/routes/lists/[id]/create-item/+page.server.ts
+++ b/src/routes/lists/[id]/create-item/+page.server.ts
@@ -14,7 +14,7 @@ export const load: PageServerLoad = async ({ locals, params, url }) => {
     const $t = await getFormatter();
 
     if (!locals.user) {
-        redirect(302, `/login?ref=${url.pathname}`);
+        redirect(302, `/login?ref=${url.pathname + url.search}`);
     }
 
     const activeMembership = await getActiveMembership(locals.user);


### PR DESCRIPTION
Adds basic bookmarklet support. Currently will only work if the list you put in the bookmarklet is in the active group. With the addition of multiple lists per user, I may consider adding additional scope to this and bring the user to a list picker before importing the url.

Closes #225 