### PR TITLE
Uncaught promise exception

### DIFF
--- a/src/lib/server/events/sse.ts
+++ b/src/lib/server/events/sse.ts
@@ -30,7 +30,7 @@ export function createSSE(retry = 0) {
                 }
             }
             emitter.on(handler.getEventId(), listener);
-            await writer.closed;
+            await writer.closed.catch(() => {});
             emitter.off(handler.getEventId(), listener);
         }
     };


### PR DESCRIPTION
There is an uncaught promise exception on the /events resource that causes a server crash. Previously this was caught and it was removed cus i thought it wasn't needed