### PR TITLE
Fix: price formatter using browser locale in non-browser contexts

### DIFF
--- a/src/lib/price-formatter.ts
+++ b/src/lib/price-formatter.ts
@@ -23,7 +23,7 @@ const getMaximumFractionDigits = (currency: string, locale?: string) => {
 
 export const getFormatter = (currency: string | null, locale?: string) => {
     return getNumberFormatter({
-        locale: locale ? locale : browser ? getLocale() : defaultLocale,
+        locale: locale ?? (browser ? getLocale() : defaultLocale),
         style: "currency",
         currency: currency || env.PUBLIC_DEFAULT_CURRENCY,
         currencyDisplay: "narrowSymbol"

--- a/src/lib/price-formatter.ts
+++ b/src/lib/price-formatter.ts
@@ -1,7 +1,8 @@
 import { env } from "$env/dynamic/public";
 import type { ItemPrice } from "@prisma/client";
 import { getNumberFormatter } from "svelte-i18n";
-import { getLocale } from "./i18n";
+import { defaultLocale, getLocale } from "./i18n";
+import { browser } from "$app/environment";
 
 type ItemWithPrice = {
     price?: string | null;
@@ -16,45 +17,41 @@ export type LocaleConfig = {
     suffix: string;
 };
 
-const getMaximumFractionDigits = (currency: string) => {
-    return getFormatter(currency).resolvedOptions().maximumFractionDigits || 2;
+const getMaximumFractionDigits = (currency: string, locale?: string) => {
+    return getFormatter(currency, locale).resolvedOptions().maximumFractionDigits || 2;
 };
 
-export const getFormatter = (currency: string | null) => {
+export const getFormatter = (currency: string | null, locale?: string) => {
     return getNumberFormatter({
-        locale: getLocale(),
+        locale: locale ? locale : browser ? getLocale() : defaultLocale,
         style: "currency",
         currency: currency || env.PUBLIC_DEFAULT_CURRENCY,
         currencyDisplay: "narrowSymbol"
     });
 };
 
-export const formatPrice = (item: ItemWithPrice) => {
+export const formatPrice = (item: ItemWithPrice, locale?: string) => {
     if (!item.itemPrice) {
         return item.price;
     }
 
-    const formatter = getFormatter(item.itemPrice.currency);
-    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency);
+    const formatter = getFormatter(item.itemPrice.currency, locale);
+    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency, locale);
 
     const value = item.itemPrice.value / Math.pow(10, maxFracDigits);
     return formatter.format(value);
 };
 
-export const formatNumberAsPrice = (price: number) => {
-    return getFormatter(null).format(price);
-};
-
-export const getPriceValue = (item: ItemWithPrice) => {
+export const getPriceValue = (item: ItemWithPrice, locale?: string) => {
     if (!item.itemPrice) {
         return null;
     }
-    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency);
+    const maxFracDigits = getMaximumFractionDigits(item.itemPrice.currency, locale);
     return item.itemPrice.value / Math.pow(10, maxFracDigits);
 };
 
-export const getMinorUnits = (value: number, currency: string) => {
-    const maxFracDigits = getMaximumFractionDigits(currency);
+export const getMinorUnits = (value: number, currency: string, locale?: string) => {
+    const maxFracDigits = getMaximumFractionDigits(currency, locale);
     return value * Math.pow(10, maxFracDigits);
 };
 

--- a/src/lib/server/api-common.ts
+++ b/src/lib/server/api-common.ts
@@ -1,3 +1,4 @@
+import { getLocale } from "$lib/server/i18n";
 import { getMinorUnits } from "$lib/price-formatter";
 import type { Prisma } from "@prisma/client";
 
@@ -17,7 +18,7 @@ export const patchItem = (body: Record<string, unknown>) => {
     if (body.price && typeof body.price === "number" && body.currency && typeof body.currency === "string") {
         data.itemPrice = {
             create: {
-                value: getMinorUnits(body.price, body.currency),
+                value: getMinorUnits(body.price, body.currency, getLocale()),
                 currency: body.currency
             },
             delete: true

--- a/src/lib/server/i18n.ts
+++ b/src/lib/server/i18n.ts
@@ -10,8 +10,7 @@ export type MessageFormatter = Awaited<ReturnType<typeof getFormatter>>;
 
 export async function getFormatter(locale?: string) {
     if (!locale) {
-        const evt = getRequestEvent();
-        locale = evt.locals.locale;
+        locale = getLocale();
     }
     await waitLocale(locale);
     return (id: string, options?: Omit<MessageObject, "id">) => {
@@ -21,4 +20,8 @@ export async function getFormatter(locale?: string) {
         }
         return get(format)(id, options_);
     };
+}
+
+export function getLocale() {
+    return getRequestEvent().locals.locale;
 }

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -3,10 +3,10 @@ import { zxcvbn, zxcvbnOptions } from "@zxcvbn-ts/core";
 import { loadOptions, meterLabel } from "$lib/zxcvbn";
 import { getConfig } from "./config";
 import { getFormatter } from "./i18n";
-import { getRequestEvent } from "$app/server";
+import { getLocale } from "$lib/server/i18n";
 
 const passwordZxcvbn = async (minScore: number) => {
-    await loadOptions(getRequestEvent().locals.locale).then((options) => zxcvbnOptions.setOptions(options));
+    await loadOptions(getLocale()).then((options) => zxcvbnOptions.setOptions(options));
     const $t = await getFormatter();
     const minStrength = $t(meterLabel[minScore]);
     const message = $t("errors.password-min-strength", { values: { minStrength } });

--- a/src/routes/items/[itemId]/edit/+page.server.ts
+++ b/src/routes/items/[itemId]/edit/+page.server.ts
@@ -6,7 +6,7 @@ import { getActiveMembership } from "$lib/server/group-membership";
 import { createImage, tryDeleteImage } from "$lib/server/image-util";
 import { itemEmitter } from "$lib/server/events/emitters";
 import { getMinorUnits } from "$lib/price-formatter";
-import { getFormatter } from "$lib/server/i18n";
+import { getFormatter, getLocale } from "$lib/server/i18n";
 import { ItemEvent } from "$lib/events";
 import { getItemInclusions } from "$lib/server/items";
 import { getAvailableLists } from "$lib/server/list";
@@ -115,7 +115,7 @@ export const actions: Actions = {
             await client.itemPrice
                 .create({
                     data: {
-                        value: getMinorUnits(parseFloat(price), currency),
+                        value: getMinorUnits(parseFloat(price), currency, getLocale()),
                         currency
                     }
                 })

--- a/src/routes/lists/[id]/create-item/+page.server.ts
+++ b/src/routes/lists/[id]/create-item/+page.server.ts
@@ -6,7 +6,7 @@ import { getActiveMembership } from "$lib/server/group-membership";
 import { createImage } from "$lib/server/image-util";
 import { itemEmitter } from "$lib/server/events/emitters";
 import { getMinorUnits } from "$lib/price-formatter";
-import { getFormatter } from "$lib/server/i18n";
+import { getFormatter, getLocale } from "$lib/server/i18n";
 import { getAvailableLists, getById } from "$lib/server/list";
 import { ItemEvent } from "$lib/events";
 import { getItemInclusions } from "$lib/server/items";
@@ -80,7 +80,7 @@ export const actions: Actions = {
             await client.itemPrice
                 .create({
                     data: {
-                        value: getMinorUnits(parseFloat(price), currency),
+                        value: getMinorUnits(parseFloat(price), currency, getLocale()),
                         currency
                     }
                 })


### PR DESCRIPTION
Small oversight that the pricing formatter was being used in server contexts but attempting to pull the locale from a browser context.
Fixes #304 