### PR TITLE
fix: hide claimed count from item owner

### DIFF
--- a/src/lib/components/wishlists/ItemDrawer.svelte
+++ b/src/lib/components/wishlists/ItemDrawer.svelte
@@ -84,10 +84,12 @@
             <iconify-icon icon="ion:gift"></iconify-icon>
             <div class="flex flex-row flex-wrap gap-x-2">
                 <span>{$t("wishes.quantity-desired", { values: { quantity: item.quantity } })}</span>
-                <span>·</span>
-                <span class="text-secondary-700-200-token font-bold">
-                    {$t("wishes.quantity-claimed", { values: { quantity: item.claimedQuantity } })}
-                </span>
+                {#if user?.id !== item.userId}
+                    <span>·</span>
+                    <span class="text-secondary-700-200-token font-bold">
+                        {$t("wishes.quantity-claimed", { values: { quantity: item.claimedQuantity } })}
+                    </span>
+                {/if}
             </div>
         </div>
     {/if}


### PR DESCRIPTION
Fixes some unintended behavior where a user could see the claimed count for items on their list within the item drawer