### PR TITLE
fix: remove email & username case sensitivity

### DIFF
--- a/prisma/migrations/20250914222933_email_case_insensitivity/migration.sql
+++ b/prisma/migrations/20250914222933_email_case_insensitivity/migration.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_user" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "username" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL DEFAULT 'changeme@email.com' COLLATE NOCASE,
+    "picture" TEXT,
+    "roleId" INTEGER NOT NULL DEFAULT 1,
+    "hashedPassword" TEXT NOT NULL, 
+    "oauthId" TEXT, 
+    "preferredLanguage" TEXT,
+    CONSTRAINT "user_roleId_fkey" FOREIGN KEY ("roleId") REFERENCES "role" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+INSERT INTO "new_user" ("id", "username", "name", "email", "picture", "roleId", "hashedPassword", "oauthId", "preferredLanguage")
+SELECT "id", "username", "name", "email", "picture", "roleId", "hashedPassword", "oauthId", "preferredLanguage"
+FROM "user";
+
+DROP TABLE "user";
+
+ALTER TABLE "new_user" RENAME TO "user";
+CREATE UNIQUE INDEX "user_id_key" ON "user"("id");
+CREATE UNIQUE INDEX "user_username_key" ON "user"("username");
+CREATE UNIQUE INDEX "user_email_key" ON "user"("email");
+
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/migrations/20250914222933_email_case_insensitivity/migration.sql
+++ b/prisma/migrations/20250914222933_email_case_insensitivity/migration.sql
@@ -1,7 +1,7 @@
 PRAGMA foreign_keys=OFF;
 CREATE TABLE "new_user" (
     "id" TEXT NOT NULL PRIMARY KEY,
-    "username" TEXT NOT NULL,
+    "username" TEXT NOT NULL COLLATE NOCASE,
     "name" TEXT NOT NULL,
     "email" TEXT NOT NULL DEFAULT 'changeme@email.com' COLLATE NOCASE,
     "picture" TEXT,

--- a/src/lib/components/CreateAccountForm.svelte
+++ b/src/lib/components/CreateAccountForm.svelte
@@ -17,8 +17,6 @@
 
     let password = $state("");
     let passwordConfirm = $state("");
-
-    $inspect(formData);
 </script>
 
 <div class="bg-surface-100-800-token ring-outline-token flex flex-col space-y-4 p-4 rounded-container-token">

--- a/src/lib/components/CreateAccountForm.svelte
+++ b/src/lib/components/CreateAccountForm.svelte
@@ -17,6 +17,8 @@
 
     let password = $state("");
     let passwordConfirm = $state("");
+
+    $inspect(formData);
 </script>
 
 <div class="bg-surface-100-800-token ring-outline-token flex flex-col space-y-4 p-4 rounded-container-token">
@@ -71,6 +73,10 @@
     {/if}
     {#if formData?.errors?.password}
         <span class="unstyled text-xs text-red-500">{formData.errors.password[0]}</span>
+    {/if}
+
+    {#if formData?.error && formData?.message}
+        <span class="unstyled text-xs text-red-500">{formData.message}</span>
     {/if}
 
     {#if !hideActions}

--- a/src/lib/components/account/EditProfile.svelte
+++ b/src/lib/components/account/EditProfile.svelte
@@ -9,8 +9,6 @@
 
     let { user = $bindable() }: Props = $props();
     const t = getFormatter();
-
-    $inspect(page.form);
 </script>
 
 <form method="POST" use:enhance>

--- a/src/lib/components/account/EditProfile.svelte
+++ b/src/lib/components/account/EditProfile.svelte
@@ -9,6 +9,8 @@
 
     let { user = $bindable() }: Props = $props();
     const t = getFormatter();
+
+    $inspect(page.form);
 </script>
 
 <form method="POST" use:enhance>

--- a/src/lib/server/user.ts
+++ b/src/lib/server/user.ts
@@ -5,7 +5,9 @@ import type { User } from "@prisma/client";
 import { create } from "./list";
 import { hashPassword } from "./password";
 
-type UserMinimal = Pick<User, "username" | "email" | "name">;
+interface UserMinimal extends Pick<User, "username" | "email" | "name"> {
+    oauthId?: string | null;
+}
 
 export const createUser = async (user: UserMinimal, role: Role, password: string, signupTokenId?: string) => {
     const config = await getConfig();
@@ -43,7 +45,8 @@ export const createUser = async (user: UserMinimal, role: Role, password: string
             name: user.name,
             email: user.email,
             roleId: role,
-            hashedPassword
+            hashedPassword,
+            oauthId: user.oauthId
         }
     });
 

--- a/src/routes/account/+page.server.ts
+++ b/src/routes/account/+page.server.ts
@@ -61,11 +61,16 @@ export const actions: Actions = {
             const err = e as PrismaClientKnownRequestError;
             logger.error({ err: e });
             const targets = err.meta?.target as string[];
+            const errors = targets.reduce(
+                (prev, target) => ({
+                    ...prev,
+                    [target]: [$t("errors.username-already-in-use", { values: { username: target } })]
+                }),
+                {}
+            );
             return fail(400, {
                 error: true,
-                errors: {
-                    username: [$t("errors.username-already-in-use", { values: { username: targets[0] } })]
-                }
+                errors
             });
         }
     },

--- a/src/routes/login/oidc/callback/+server.ts
+++ b/src/routes/login/oidc/callback/+server.ts
@@ -78,7 +78,8 @@ export const POST: RequestHandler = async (event) => {
     const userData = {
         name: userinfo.name ?? userinfo.email,
         username: userinfo.preferred_username ?? userinfo.email,
-        email: userinfo.email
+        email: userinfo.email,
+        oauthId: userinfo.sub
     };
     logger.debug(userData, "Registering a new user");
     user = await createUser(userData, Role.USER, "");

--- a/src/routes/signup/+page.server.ts
+++ b/src/routes/signup/+page.server.ts
@@ -97,7 +97,7 @@ export const actions: Actions = {
             logger.error({ err }, "User with username or email already exists");
             return fail(400, {
                 error: true,
-                errors: [{ field: "username", message: $t("errors.user-already-exists") }]
+                message: $t("errors.user-already-exists")
             });
         }
     }


### PR DESCRIPTION
Emails are generally considered case-insensitive. Emails must be unique for each user, but variations in casing were previously allowed. The migration makes the user's email case-insensitive, which is a breaking change and may result in failed migration in cases where multiple users share the same email, but with different casing.

Closes https://github.com/cmintey/wishlist/issues/398