### PR TITLE
fix: region-specific locales not working

### DIFF
--- a/src/lib/components/wishlists/chips/ListFilterChip.svelte
+++ b/src/lib/components/wishlists/chips/ListFilterChip.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { User } from "@prisma/client";
     import BaseChip from "./BaseChip.svelte";
-    import { getFormatter, getLocale } from "$lib/i18n";
+    import { defaultLang, getFormatter, getLocale } from "$lib/i18n";
     import type { ClassValue } from "svelte/elements";
 
     type PartialUser = Pick<User, "id" | "name" | "picture">;
@@ -34,7 +34,7 @@
                 return unique;
             })
             .map((user) => ({ value: user.id, displayValue: user.name }) as Option)
-            .toSorted((a, b) => a.displayValue.localeCompare(b.displayValue, locale || "en-US"));
+            .toSorted((a, b) => a.displayValue.localeCompare(b.displayValue, locale || defaultLang.code));
     }
 </script>
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,7 +1,7 @@
 import { register, init, format, waitLocale } from "svelte-i18n";
 import { derived, type Readable } from "svelte/store";
 import type { MessageObject, MessageFormatter } from "./server/i18n";
-import { getContext, setContext } from "svelte";
+import { createContext } from "svelte";
 import { dev } from "$app/environment";
 
 export interface Lang {
@@ -61,6 +61,11 @@ export const supportedLangs: Lang[] = [
     }
 ];
 
+const supportedLangsByCode: Record<string, Lang> = supportedLangs.reduce(
+    (accum, lang) => ({ ...accum, [lang.code]: lang }),
+    {}
+);
+
 export async function initFormatter(locale: string) {
     await waitLocale(locale);
     return derived(format, ($format) => {
@@ -74,21 +79,8 @@ export async function initFormatter(locale: string) {
     });
 }
 
-export function setFormatter(t: Readable<MessageFormatter>) {
-    setContext("translator", t);
-}
-
-export function getFormatter() {
-    return getContext("translator") as Readable<MessageFormatter>;
-}
-
-export function setLocale(locale: string) {
-    setContext("locale", locale);
-}
-
-export function getLocale() {
-    return (getContext("locale") as string) || defaultLang.code;
-}
+export const [getFormatter, setFormatter] = createContext<Readable<MessageFormatter>>();
+export const [getLocale, setLocale] = createContext<string>();
 
 export const initLang = async (locale: string) => {
     supportedLangs.forEach((lang) => register(lang.code, lang.loader));
@@ -123,12 +115,23 @@ export const getClosestAvailablePreferredLanguage = (preferredLanguage: string |
 };
 
 export const getClosestAvailableLocale = (langs: readonly string[]): Lang => {
-    const availableLangs = langs
-        .map((lang) => supportedLangs.find((supportedLang) => supportedLang.code === lang))
-        .filter((lang) => lang !== undefined);
-    return availableLangs.length > 0 ? availableLangs[0] : defaultLang;
+    const langsAndSubLangs = langs.flatMap((lang) => getSubLocales(lang));
+    for (const lang of langsAndSubLangs) {
+        if (lang in supportedLangsByCode) {
+            return supportedLangsByCode[lang];
+        }
+    }
+    return defaultLang;
 };
 
 export const getPrimaryLang = (locale: string) => {
     return locale?.toLowerCase().split("-")[0];
+};
+
+// https://github.com/kaisermann/svelte-i18n/blob/780932a3e1270d521d348aac8ba03be9df309f04/src/runtime/stores/locale.ts#L11
+const getSubLocales = (refLocale: string) => {
+    return refLocale
+        .split("-")
+        .map((_, i, arr) => arr.slice(0, i + 1).join("-"))
+        .reverse();
 };

--- a/src/routes/admin/about/+page.svelte
+++ b/src/routes/admin/about/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import { getFormatter, getLocale } from "$lib/i18n";
+    import { defaultLang, getFormatter, getLocale } from "$lib/i18n";
     import { getDateFormatter } from "svelte-i18n";
 
     const t = getFormatter();
     const date = getDateFormatter({
-        locale: getLocale(),
+        locale: getLocale() || defaultLang.code,
         format: "medium"
     });
     const version: string = __VERSION__;


### PR DESCRIPTION
Wishlist doesn't declare any region-specific locales generally. Most browsers have a fallback to a region-specific locale such as `fr-FR, fr`, so that `fr` is the language which is chosen. However in cases where a general language code is not provided, Wishlist is unable determine a matching language.

This PR adds a step to expand the region-specific locale into both it's specific and generic language code so that if the specific language is not available, the generic language will still be used.

Closes #458 