### PR TITLE
fix: Config persistence issue

### DIFF
--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -74,7 +74,7 @@ const transformers: Record<ConfigKey, Transformer<unknown>> = {
     "oidc.disableEmailVerification": booleanTransformer
 };
 
-const defaultConfig: Config = {
+const getDefaultConfig = (): Config => ({
     enableSignup: true,
     suggestions: {
         enable: true,
@@ -98,7 +98,7 @@ const defaultConfig: Config = {
     oidc: {
         enable: false
     }
-};
+});
 
 function buildConfig(configMap: Record<string, string | null>, includeSensitive = false): Config {
     const config: Partial<Config> = {};
@@ -111,7 +111,7 @@ function buildConfig(configMap: Record<string, string | null>, includeSensitive 
         }
     }
 
-    return deepMerge(defaultConfig, config) as Config;
+    return deepMerge(getDefaultConfig(), config) as Config;
 }
 
 function setDeep(obj: Record<string, any>, path: string[], value: any) {


### PR DESCRIPTION
The defaultConfig is created once and group configs override it by setting writing directly to the defaultConfig object. This causes issues when switching between groups that have different overrides for settings and the override not working if the group doesn't have an override.