### PR TITLE
fix: attempt to fix non-root docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM node:24-slim@sha256:76d0ed0ed93bed4f4376211e9d8fddac4d8b3fbdb54cc45955696001a3c91152 AS base
 WORKDIR /usr/src/app
-ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable pnpm && corepack install -g pnpm@latest-10
+RUN npm install -g pnpm@latest-10
 
 # Build step
 FROM base AS build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 export PROTOCOL_HEADER=x-forwarded-proto 
 export HOST_HEADER=x-forwarded-host
-export DATABASE_URL="file:/usr/src/app/data/prod.db?connection_limit=1"
+export DATABASE_URL="file:/usr/src/app/data/prod.db"
 export PUBLIC_DEFAULT_CURRENCY=${DEFAULT_CURRENCY}
 
 caddy start --config /usr/src/app/Caddyfile


### PR DESCRIPTION
Removes Corepack from the docker image to see if that is what is preventing non-root users from running Wishlist in docker. Also removes the connection limit of 1 since WAL mode is now enabled for sqlite