### PR TITLE
adjust claim name logic

### DIFF
--- a/src/lib/components/modals/ClaimItemModal.svelte
+++ b/src/lib/components/modals/ClaimItemModal.svelte
@@ -191,7 +191,7 @@
             </div>
         {/if}
 
-        <footer class={["flex flex-wrap gap-2", claim ? "justify-between" : "justify-end"]}>
+        <footer class={["flex flex-wrap gap-2 pt-2", claim ? "justify-between" : "justify-end"]}>
             {#if claim}
                 <button class="variant-filled-error btn btn-sm md:btn-base" onclick={onUnclaim} type="button">
                     {$t("wishes.unclaim")}

--- a/src/lib/components/wishlists/ItemCard/ClaimButtons.svelte
+++ b/src/lib/components/wishlists/ItemCard/ClaimButtons.svelte
@@ -62,9 +62,9 @@
             {$t("wishes.claim")}
         </button>
     </div>
-{:else if item.claims.length === 0}
+{:else if item.claims.length === 0 || (item.userId === user?.id && item.isClaimable)}
     <div></div>
-{:else if item.claims.length === 1 && shouldShowName(showName, onPublicList, user, item.claims[0])}
+{:else if item.claims.length === 1 && shouldShowName(item, showName, showForOwner, user, item.claims[0])}
     <span>
         {$t("wishes.claimed-by", {
             values: {
@@ -72,7 +72,7 @@
             }
         })}
     </span>
-{:else if item.claims.length > 1 && shouldShowName(showName, onPublicList, user)}
+{:else if item.claims.length > 1 && shouldShowName(item, showName, showForOwner, user)}
     <span>{$t("wishes.claimed-by-multiple-users")}</span>
 {:else}
     <span>{$t("wishes.claimed")}</span>

--- a/src/lib/components/wishlists/ItemDrawer.svelte
+++ b/src/lib/components/wishlists/ItemDrawer.svelte
@@ -33,19 +33,6 @@
 
     let expandClaims = $state(false);
 
-    const groupedClaims = $derived(
-        item.claims.reduce(
-            (acc, claim) => {
-                const name = shouldShowName(showClaimedName, onPublicList, user, claim)
-                    ? getClaimedName(claim)
-                    : $t("wishes.anonymous");
-                acc[name] = (acc[name] || 0) + claim.quantity;
-                return acc;
-            },
-            {} as Record<string, number>
-        )
-    );
-
     const onEdit = () => {
         goto(page.url.pathname, { replaceState: true, noScroll: true });
         drawerStore.close();
@@ -121,12 +108,13 @@
                 </button>
 
                 {#if expandClaims}
-                    <div class="px-2 pb-2">
-                        {#each Object.entries(groupedClaims) as [name, claimCount]}
+                    <div class="max-h-32 overflow-scroll px-2 pb-2">
+                        {#each item.claims as claim}
+                            {@const showName = shouldShowName(item, showClaimedName, showClaimForOwner, user, claim)}
                             <div class="flex items-center justify-between py-1">
-                                <span>{name}</span>
+                                <span>{showName ? getClaimedName(claim) : $t("wishes.anonymous")}</span>
                                 <span>
-                                    {$t("wishes.claims", { values: { claimCount } })}
+                                    {$t("wishes.claims", { values: { claimCount: claim.quantity } })}
                                 </span>
                             </div>
                         {/each}

--- a/src/lib/components/wishlists/util.ts
+++ b/src/lib/components/wishlists/util.ts
@@ -1,4 +1,4 @@
-import type { ClaimDTO } from "$lib/dtos/item-dto";
+import type { ClaimDTO, ItemOnListDTO } from "$lib/dtos/item-dto";
 import { getFormatter } from "$lib/i18n";
 import { get } from "svelte/store";
 import type { PartialUser } from "./ItemCard/ItemCard.svelte";
@@ -15,18 +15,27 @@ export const getClaimedName = ({ claimedBy, publicClaimedBy }: ClaimDTO) => {
 };
 
 export const shouldShowName = (
+    item: ItemOnListDTO,
     showNameConfig: boolean,
-    onPublicList: boolean,
+    showForOwner: boolean,
     user: PartialUser | undefined,
     claim?: ClaimDTO
 ) => {
-    if (showNameConfig) {
-        if (onPublicList && claim?.publicClaimedBy?.name) {
-            return true;
-        }
-        if (user && claim?.claimedBy?.groups.includes(user.activeGroupId) && claim.claimedBy?.name) {
-            return true;
-        }
+    // Completely disabled
+    if (!showNameConfig) {
+        return false;
     }
-    return false;
+    // No logged in user
+    if (!user) {
+        return false;
+    }
+    // List owner can only view if the config is set
+    if (item.user.id === user.id && showForOwner) {
+        return true;
+    }
+    // Everyone else can only see claims by users in their group
+    if (claim && (claim.publicClaimedBy || !claim.claimedBy?.groups.includes(user.activeGroupId))) {
+        return false;
+    }
+    return true;
 };


### PR DESCRIPTION
Adjusts the claim name logic. Now
1. Anonymous users on a public list won't see claim names no matter what
2. List owners can always view claim names when the configuration option is checked
3. Other users can only see claim names for other users who are in a shared group

Closes #505 