### PR TITLE
feat: alllow smtp to be configured without auth

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -51,8 +51,8 @@ type SMTPConfig =
           enable: true;
           host: string;
           port: number;
-          user: string;
-          pass: string;
+          user?: string;
+          pass?: string;
           from: string;
           fromName: string;
       };

--- a/src/lib/components/admin/Settings/Email/Email.svelte
+++ b/src/lib/components/admin/Settings/Email/Email.svelte
@@ -17,13 +17,7 @@
     let config = $state(config_);
     let enabled = $state(config.smtp.enable);
     let allFilled = $derived(
-        enabled &&
-            config.smtp.from &&
-            config.smtp.fromName &&
-            config.smtp.host &&
-            config.smtp.pass &&
-            config.smtp.port &&
-            config.smtp.user
+        enabled && config.smtp.from && config.smtp.fromName && config.smtp.host && config.smtp.port
     );
 
     $inspect(config.smtp);
@@ -72,7 +66,6 @@
                         name="smtpUser"
                         class="input"
                         autocomplete="off"
-                        required
                         type="text"
                         bind:value={config.smtp.user}
                     />
@@ -81,7 +74,6 @@
                     id="smtpPass"
                     name="smtpPass"
                     label={$t("auth.password")}
-                    required
                     bind:value={config.smtp.pass}
                 />
                 <label for="smtpFrom">

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -44,13 +44,7 @@ const sendEmail = async (options: Mail.Options) => {
 
     if (
         !config.smtp.enable ||
-        (config.smtp.enable &&
-            !config.smtp.host &&
-            !config.smtp.port &&
-            !config.smtp.user &&
-            !config.smtp.pass &&
-            !config.smtp.from &&
-            !config.smtp.fromName)
+        (config.smtp.enable && !config.smtp.host && !config.smtp.port && !config.smtp.from && !config.smtp.fromName)
     ) {
         logger.error("SMTP not set up properly, check your settings");
         return {
@@ -62,10 +56,7 @@ const sendEmail = async (options: Mail.Options) => {
     const transport = nodemailer.createTransport({
         port: config.smtp.port,
         host: config.smtp.host,
-        auth: {
-            user: config.smtp.user,
-            pass: config.smtp.pass
-        }
+        auth: config.smtp.user && config.smtp.pass ? { user: config.smtp.user, pass: config.smtp.pass } : undefined
     });
 
     return await transport

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -30,8 +30,8 @@ export const actions: Actions = {
     "send-test": async () => {
         const user = await requireRole(Role.ADMIN);
 
-        await sendTest(user.email);
-        return { action: "send-test", success: true };
+        const resp = await sendTest(user.email);
+        return { action: "send-test", ...resp };
     },
     settings: async ({ request }) => {
         await requireRole(Role.ADMIN);
@@ -56,8 +56,8 @@ const generateConfig = (configData: z.infer<typeof settingSchema>) => {
               enable: true,
               host: configData.smtpHost!,
               port: configData.smtpPort!,
-              user: configData.smtpUser!,
-              pass: configData.smtpPass!,
+              user: configData.smtpUser,
+              pass: configData.smtpPass,
               from: configData.smtpFrom!,
               fromName: configData.smtpFromName!
           }

--- a/src/routes/admin/settings/+page.svelte
+++ b/src/routes/admin/settings/+page.svelte
@@ -7,6 +7,7 @@
     import type { PageProps } from "./$types";
     import { getToastStore, ProgressRadial } from "@skeletonlabs/skeleton";
     import { getFormatter } from "$lib/i18n";
+    import { errorToast } from "$lib/components/toasts";
 
     const { data }: PageProps = $props();
     const t = getFormatter();
@@ -43,7 +44,14 @@
             }
             if (action.search.endsWith("?/send-test") && result.type === "success") {
                 sending = false;
-                toastStore.trigger({ message: $t("admin.test-email-sent-toast") });
+                if (!result.data?.success) {
+                    const message: string = result.data?.message
+                        ? (result.data.message as string)
+                        : $t("errors.something-went-wrong");
+                    errorToast(toastStore, message);
+                } else {
+                    toastStore.trigger({ message: $t("admin.test-email-sent-toast") });
+                }
             }
         };
     }}


### PR DESCRIPTION
Makes user and pass fields optional for SMTP, allowing for users to use unauthenticated email proxies.
Closes #510