### PR TITLE
feat: hide unclaim button when claim is on a list in another group

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -369,6 +369,7 @@
         "claimed": "Claimed",
         "claimed-by": "Claimed by {name}",
         "claimed-by-multiple-users": "Claimed by multiple users",
+        "claimed-by-you-on-another-list": "Claimed by you on another list",
         "claimed-info-text": "{claimedQuantity, plural, one {You've claimed # item.} other {You've claimed # items.}}",
         "claimed-item": "{claimed, select, true {Claimed} other {Unclaimed}} item",
         "claims": "{claimCount, plural, one {# claim} other {# claims}}",

--- a/src/lib/components/wishlists/ItemCard/ClaimButtons.svelte
+++ b/src/lib/components/wishlists/ItemCard/ClaimButtons.svelte
@@ -29,37 +29,42 @@
     const t = getFormatter();
 
     const userClaim = $derived(item.claims.find((claim) => claim.claimedBy && claim.claimedBy.id === user?.id));
+    const isClaimOnList = $derived(userClaim?.listId === item.listId);
 </script>
 
 {#if !onPublicList && item.userId === user?.id && !showClaimForOwner}
     <div></div>
 {:else if userClaim}
-    <div class="flex flex-row gap-2">
-        <button
-            class="variant-ghost-secondary btn btn-sm md:btn"
-            onclick={(e) => {
-                e.stopPropagation();
-                onUnclaim?.();
-            }}
-        >
-            {item.quantity === 1 && userClaim.quantity === 1 ? $t("wishes.unclaim") : $t("wishes.update-claim")}
-        </button>
-        <button
-            class={[
-                "btn btn-icon btn-icon-sm md:btn-icon-base",
-                userClaim.purchased && "variant-soft-secondary",
-                !userClaim.purchased && "variant-ringed-secondary"
-            ]}
-            aria-label={userClaim.purchased ? $t("a11y.unpurchase") : $t("wishes.purchase")}
-            onclick={(e) => {
-                e.stopPropagation();
-                onPurchased?.(!userClaim.purchased);
-            }}
-            title={userClaim.purchased ? $t("a11y.unpurchase") : $t("wishes.purchase")}
-        >
-            <iconify-icon icon={userClaim.purchased ? "ion:bag-check" : "ion:bag"}></iconify-icon>
-        </button>
-    </div>
+    {#if isClaimOnList}
+        <div class="flex flex-row gap-2">
+            <button
+                class="variant-ghost-secondary btn btn-sm md:btn"
+                onclick={(e) => {
+                    e.stopPropagation();
+                    onUnclaim?.();
+                }}
+            >
+                {item.quantity === 1 && userClaim.quantity === 1 ? $t("wishes.unclaim") : $t("wishes.update-claim")}
+            </button>
+            <button
+                class={[
+                    "btn btn-icon btn-icon-sm md:btn-icon-base",
+                    userClaim.purchased && "variant-soft-secondary",
+                    !userClaim.purchased && "variant-ringed-secondary"
+                ]}
+                aria-label={userClaim.purchased ? $t("a11y.unpurchase") : $t("wishes.purchase")}
+                onclick={(e) => {
+                    e.stopPropagation();
+                    onPurchased?.(!userClaim.purchased);
+                }}
+                title={userClaim.purchased ? $t("a11y.unpurchase") : $t("wishes.purchase")}
+            >
+                <iconify-icon icon={userClaim.purchased ? "ion:bag-check" : "ion:bag"}></iconify-icon>
+            </button>
+        </div>
+    {:else}
+        <span class="text-subtle text-wrap">{$t("wishes.claimed-by-you-on-another-list")}</span>
+    {/if}
 {:else if item.isClaimable && item.userId !== user?.id}
     <div class="flex flex-row items-center gap-x-2">
         <button
@@ -75,7 +80,7 @@
 {:else if item.claims.length === 0 || (item.userId === user?.id && item.isClaimable)}
     <div></div>
 {:else if item.claims.length === 1 && shouldShowName(item, showClaimedName, showClaimForOwner, user, item.claims[0])}
-    <span class="line-clamp-2 truncate text-wrap">
+    <span class="text-subtle line-clamp-2 truncate text-wrap">
         {$t("wishes.claimed-by", {
             values: {
                 name: getClaimedName(item.claims[0])
@@ -83,7 +88,7 @@
         })}
     </span>
 {:else if item.claims.length > 1 && shouldShowName(item, showClaimedName, showClaimForOwner, user)}
-    <span class="line-clamp-2 truncate text-wrap">{$t("wishes.claimed-by-multiple-users")}</span>
+    <span class="text-subtle line-clamp-2 truncate text-wrap">{$t("wishes.claimed-by-multiple-users")}</span>
 {:else}
-    <span class="line-clamp-2 truncate text-wrap">{$t("wishes.claimed")}</span>
+    <span class="text-subtle line-clamp-2 truncate text-wrap">{$t("wishes.claimed")}</span>
 {/if}

--- a/src/lib/components/wishlists/chips/GroupSelectChip.svelte
+++ b/src/lib/components/wishlists/chips/GroupSelectChip.svelte
@@ -47,7 +47,7 @@
     <ul class="max-h-72 overflow-scroll">
         {#each groups as group (group.id)}
             <li>
-                <button class="list-option w-fit justify-between" onclick={() => onSelect(group)}>
+                <button class="list-option w-full justify-between" onclick={() => onSelect(group)}>
                     <span class="max-w-full truncate">{group.name}</span>
                     {#if group.id === activeGroup.id}
                         <iconify-icon icon="ion:checkmark"></iconify-icon>

--- a/src/lib/dtos/item-dto.ts
+++ b/src/lib/dtos/item-dto.ts
@@ -9,6 +9,7 @@ interface UserWithGroups extends MinimalUser {
 type BaseClaim = {
     claimId: string;
     quantity: number;
+    listId: string;
 };
 
 interface Claimed extends BaseClaim {

--- a/src/lib/dtos/item-mapper.ts
+++ b/src/lib/dtos/item-mapper.ts
@@ -15,7 +15,7 @@ interface UserWithGroups extends MinimalUser {
     UserGroupMembership: Pick<UserGroupMembership, "groupId">[];
 }
 
-interface ItemClaim extends Pick<PrismaItemClaim, "id" | "purchased" | "quantity"> {
+interface ItemClaim extends Pick<PrismaItemClaim, "id" | "purchased" | "quantity" | "listId"> {
     claimedBy: UserWithGroups | null;
     publicClaimedBy: Pick<SystemUser, "id" | "name"> | null;
 }
@@ -52,9 +52,20 @@ export const toItemOnListDTO = (item: FullItem, listId: string) => {
                     ...user,
                     groups: UserGroupMembership.map(({ groupId }) => groupId)
                 };
-                return { claimId: claim.id, quantity: claim.quantity, claimedBy, purchased: claim.purchased };
+                return {
+                    claimId: claim.id,
+                    quantity: claim.quantity,
+                    claimedBy,
+                    purchased: claim.purchased,
+                    listId: claim.listId
+                };
             }
-            return { claimId: claim.id, quantity: claim.quantity, publicClaimedBy: claim.publicClaimedBy! };
+            return {
+                claimId: claim.id,
+                quantity: claim.quantity,
+                publicClaimedBy: claim.publicClaimedBy!,
+                listId: claim.listId
+            };
         }),
         listCount: _count.lists,
         get claimedQuantity(): number {

--- a/src/lib/server/items.ts
+++ b/src/lib/server/items.ts
@@ -23,6 +23,7 @@ export const getItemInclusions = (listId?: string) => {
                 id: true,
                 quantity: true,
                 purchased: true,
+                listId: true,
                 claimedBy: {
                     select: {
                         id: true,


### PR DESCRIPTION
When an item is added to multiple lists across groups and you've claimed an item in one list, it still shows as claimed on the other list, but allows you to unclaim the item. This is confusing as you can't see the claim in your My Claims page unless you are in the correct group.
Now you will see the text "claimed by you on another list" if this is the case, to avoid confusion.