### PR TITLE
fix: use overflow-auto to hide scrollbars when not needed

### DIFF
--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -24,7 +24,7 @@
     {#if previewNote}
         {#if value}
             <div
-                class="variant-ringed-surface h-28 max-w-none overflow-scroll whitespace-pre-wrap px-3 py-2 rounded-container-token"
+                class="variant-ringed-surface h-28 max-w-none overflow-auto whitespace-pre-wrap px-3 py-2 rounded-container-token"
                 data-testid="markdown-preview"
             >
                 <Markdown source={value} />

--- a/src/lib/components/wishlists/ItemCard/components/ItemAttributes.svelte
+++ b/src/lib/components/wishlists/ItemCard/components/ItemAttributes.svelte
@@ -69,7 +69,7 @@
         </button>
 
         {#if expandClaims}
-            <div class="max-h-32 overflow-scroll px-2 pb-2">
+            <div class="max-h-32 overflow-auto px-2 pb-2">
                 {#each item.claims as claim}
                     {@const showName = shouldShowName(item, showClaimedName, showClaimForOwner, user, claim)}
                     <div class="flex items-center justify-between py-1">

--- a/src/lib/components/wishlists/ItemForm.svelte
+++ b/src/lib/components/wishlists/ItemForm.svelte
@@ -338,7 +338,7 @@
         </div>
 
         <div
-            class="border-surface-400-500-token flex h-36 flex-col space-y-2 overflow-scroll p-2 border-token rounded-container-token"
+            class="border-surface-400-500-token flex h-36 flex-col space-y-2 overflow-auto p-2 border-token rounded-container-token"
             class:input-error={form?.errors?.lists}
         >
             {#each lists as list (list.id)}

--- a/src/lib/components/wishlists/chips/BaseChip.svelte
+++ b/src/lib/components/wishlists/chips/BaseChip.svelte
@@ -152,7 +152,7 @@
         ></iconify-icon>
     </button>
     <nav class="card list-nav z-10 max-h-96 p-4 shadow-xl" data-popup={popupKey}>
-        <ul class="max-h-72 overflow-scroll">
+        <ul class="max-h-72 overflow-auto">
             {#each options as option (option.value + option.direction)}
                 <li>
                     {#if multiselect}

--- a/src/lib/components/wishlists/chips/GroupSelectChip.svelte
+++ b/src/lib/components/wishlists/chips/GroupSelectChip.svelte
@@ -44,7 +44,7 @@
     ></iconify-icon>
 </button>
 <nav class="card list-nav z-10 max-h-96 max-w-full p-4 shadow-xl" data-popup={popupKey}>
-    <ul class="max-h-72 overflow-scroll">
+    <ul class="max-h-72 overflow-auto">
         {#each groups as group (group.id)}
             <li>
                 <button class="list-option w-fit justify-between" onclick={() => onSelect(group)}>


### PR DESCRIPTION
Use overflow-auto instead of overflow-scroll. Apparently on Chromium browsers, overflow-scroll always shows the scroll bar even when the content is not scrollable.

Fixes #533 