### PR TITLE
Fix locale error on signup

### DIFF
--- a/src/lib/server/i18n.ts
+++ b/src/lib/server/i18n.ts
@@ -11,7 +11,7 @@ export type MessageFormatter = Awaited<ReturnType<typeof getFormatter>>;
 
 export async function getFormatter(locale?: string) {
     if (!locale) {
-        locale = getLocale() || defaultLang.code;
+        locale = getLocale();
     }
     await waitLocale(locale);
     return (id: string, options?: Omit<MessageObject, "id">) => {
@@ -24,5 +24,5 @@ export async function getFormatter(locale?: string) {
 }
 
 export function getLocale() {
-    return getRequestEvent().locals.locale;
+    return getRequestEvent().locals.locale || defaultLang.code;
 }


### PR DESCRIPTION
Singup with origin behind reverse proxy gave this error:
```
{
  "level": "ERROR",
  "time": "2026-01-01T10:05:17.622Z",
  "status": 500,
  "method": "POST",
  "uri": "/signup",
  "err":
    {
      "type": "Error",
      "message": "[svelte-i18n] Cannot format a message without first setting the initial locale.",
      "stack": Error: [svelte-i18n] Cannot format a message without first setting the initial locale.
    at formatMessage (file:///opt/wishlist/build/server/chunks/i18n2-DEGHSCGd.js:3920:11)
    at file:///opt/wishlist/build/server/chunks/i18n-fKILqM89.js:16:24
    at passwordZxcvbn (file:///opt/wishlist/build/server/chunks/validations-Dor7Qldx.js:21:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
    at async getSignupSchema (file:///opt/wishlist/build/server/chunks/validations-Dor7Qldx.js:46:15)
    at async default (file:///opt/wishlist/build/server/chunks/31-Slf_i7uW.js:63:26)
    at async fn (file:///opt/wishlist/build/server/index.js:2658:22)
    at async handle_action_json_request (file:///opt/wishlist/build/server/index.js:2503:18)
    at async resolve2 (file:///opt/wishlist/build/server/index.js:5999:25)
    at async fn (file:///opt/wishlist/build/server/index.js:5859:16),
    },
  "msg": "Internal Error",
}
```
Mentioned in #491. Moving some logic to fix it for more places