### PR TITLE
Multiple url support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # If behind a reverse proxy, set this to your domain
 # i.e. https://wishlist.your-domain.org
 ORIGIN=
+# Additional allowed origins (comma-separated) for accessing from multiple URLs
+# Useful when you want to access via both domain name and local IP
+# i.e. http://192.168.1.100:3280,http://localhost:3280
+ALLOWED_ORIGINS=
 # Hours until signup and password reset tokens expire
 TOKEN_TIME=72
 # The currency to use when a product search does not return a currency

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ services:
     environment:
       # ORIGIN: https://wishlist.example.com
       ORIGIN: http://192.168.2.10:3280 # The URL your users will be connecting to
+      # ALLOWED_ORIGINS: http://localhost:3280,http://192.168.1.100:3280 # Additional origins (optional)
       TOKEN_TIME: 72 # hours until signup and password reset tokens expire
 ```
 
@@ -70,6 +71,8 @@ You can now connect to your application at `http://<host>:3280`.
 ### Environment Variables
 
 `ORIGIN`: The URL your users will connect to e.g. `https://wishlist.domain.com`, `http://192.168.2.10:3280`. **Note**, if this value is an IP address, then it must include the exposed port of the application
+
+`ALLOWED_ORIGINS`: Additional origins (comma-separated) that are allowed to access the application. Useful when you want to access via both a domain name and local IP address, e.g. `http://192.168.1.100:3280,http://localhost:3280`
 
 `TOKEN_TIME`: The amount of time (hours) that signup and password reset tokens are valid for
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,12 @@ const config = {
     ],
 
     kit: {
-        adapter: adapter()
+        adapter: adapter(),
+        // Disable default CSRF verification because we have our own
+        // implementation that supports multiple origins (ALLOWED_ORIGINS)
+        csrf: {
+            checkOrigin: false
+        }
     }
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -62,6 +62,7 @@ const config: UserConfig = {
         })
     ],
     server: {
+        host: true,
         fs: {
             // Allow serving files from one level up to the project root
             allow: ["./static/"]


### PR DESCRIPTION
This PR adds multiple allowed origins for CSRF protection, making it possible to access the application from several URLs (such as a domain name and a local IP address). 
It achieves this by adding a new `ALLOWED_ORIGINS` environment variable, implementing custom CSRF verification logic that checks requests against this list (it also includes updated documentation and configuration accordingly).

**CSRF Protection & Allowed Origins:**

* Added support for specifying multiple allowed origins via a new `ALLOWED_ORIGINS` environment variable, and implemented helper functions (`isAllowedOrigin`, `getAllowedOrigins`) to parse and validate origins in `src/lib/server/auth.ts`.
* Replaced SvelteKit's default CSRF protection with a custom hook (`csrfProtection`) in `src/hooks.server.ts` that checks incoming requests' origins against the allowed list, and combined it with the main handler using `sequence`. 
* Disabled SvelteKit's built-in CSRF origin checking in `svelte.config.js` to avoid conflicts with the new custom implementation.

**Documentation & Configuration:**

* Updated `.env.example` and `README.md` to document the new `ALLOWED_ORIGINS` variable and provide usage examples. 
* Enabled the Vite dev server to listen on all network interfaces (`host: true`) in `vite.config.ts`, making local network access easier for development and testing.