### PR TITLE
Update email.ts to allow localhost smtp server on port 25

### DIFF
--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -53,10 +53,18 @@ const sendEmail = async (options: Mail.Options) => {
         };
     }
 
+    // In general we will require SSL/TLS, but for local mail servers
+    // (e.g., postfix), we'll allow for insecure connections.
+
+    const isLocalhost = config.smtp.port === 25 && (config.smtp.host === "localhost" || config.smtp.host === "127.0.0.1");
+
     const transport = nodemailer.createTransport({
         port: config.smtp.port,
         host: config.smtp.host,
-        auth: config.smtp.user && config.smtp.pass ? { user: config.smtp.user, pass: config.smtp.pass } : undefined
+        auth: config.smtp.user && config.smtp.pass ? { user: config.smtp.user, pass: config.smtp.pass } : undefined,
+        ...(isLocalhost && {
+            tls: { rejectUnauthorized: false }
+        })
     });
 
     return await transport


### PR DESCRIPTION
This PR allows for the SMTP server to be configured to use (unencrypted) port 25 if the server is specified as localhost/127.0.0.1, which would be the appropriate port if postfix is set up to relay mail on the wishlist server/node.