### PR TITLE
fix: Pull to refresh with dialogs

### DIFF
--- a/src/lib/components/navigation/NavigationLoadingBar.svelte
+++ b/src/lib/components/navigation/NavigationLoadingBar.svelte
@@ -18,10 +18,10 @@
 </script>
 
 {#if progress.current}
-    <div class="absolute top-0 left-0 z-999999999 h-[3px] w-screen bg-white">
+    <div class="bg-surface-50/50 dark:bg-surface-950/50 absolute top-0 left-0 z-999999999 h-0.75 w-screen">
         <span
             style:width={`${progress.current}%`}
-            class="bg-surface-50/50 dark:bg-surface-950/50 absolute h-[3px]"
+            class="bg-surface-950/50 dark:bg-surface-50/50 absolute h-0.75"
         ></span>
     </div>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -49,16 +49,36 @@
         }
     });
 
+    let shouldPullToRefresh = $state(true);
     onMount(() => {
         if (window.matchMedia("(display-mode: standalone)").matches) {
             $isInstalled = true;
+
+            // don't PTR inside of dialogs
+            document.body.addEventListener("touchstart", (ev) => {
+                let el = ev.target as HTMLElement | null;
+                while (el && el.parentNode && el !== document.body) {
+                    if (el.scrollTop > 0) {
+                        shouldPullToRefresh = false;
+                    }
+                    if (el.getAttribute("role") === "dialog") {
+                        shouldPullToRefresh = false;
+                        break;
+                    }
+                    el = el.parentNode as HTMLElement;
+                }
+            });
+            document.body.addEventListener("touchend", () => {
+                shouldPullToRefresh = true;
+            });
             const ptr = PullToRefresh.init({
                 mainElement: document.getElementById("main") as unknown as string,
                 distThreshold: 70,
                 resistanceFunction: (t) => Math.min(1, t / 4.5),
                 onRefresh() {
                     window.location.reload();
-                }
+                },
+                shouldPullToRefresh: () => !window.scrollY && shouldPullToRefresh
             });
             return () => ptr.destroy();
         }


### PR DESCRIPTION
## Description
Pull to refresh was triggering when attempting to scroll within a dialog. This PR adds some checks to not allow that

## AI Disclosure
N/A

## Checklist
Please confirm the following before requesting review:

- [x] I have tested my changes locally
- [x] I have ran `pnpm lint` locally
- [x] I have ran `pnpm format` locally
- [x] I have ran `pnpm check` locally
- [x] I have completed the AI Disclosure
- [x] My changes do not introduce new warnings or errors
