### PR TITLE
fix: retain locale number format for currency input

### DIFF
--- a/src/lib/components/CurrencyInput.svelte
+++ b/src/lib/components/CurrencyInput.svelte
@@ -29,10 +29,6 @@
     let isMounted = $state(false);
     let previousCurrency = currency;
 
-    $inspect(localeConfig);
-    $inspect(value);
-    $inspect(inputtedValue);
-
     onMount(() => {
         isMounted = true;
     });


### PR DESCRIPTION
## Description
Use the Intl number formatter to correctly format the price to the user's locale when clicking into the input.

## Related Issues

Closes #660

## AI Disclosure
N/A

## Checklist
Please confirm the following before requesting review:

- [x] I have tested my changes locally
- [x] I have ran `pnpm lint` locally
- [x] I have ran `pnpm format` locally
- [x] I have ran `pnpm check` locally
- [x] I have completed the AI Disclosure
- [x] My changes do not introduce new warnings or errors
