### PR TITLE
fix: New items indicator alignment on list card

### DIFF
--- a/src/lib/components/ListCard.svelte
+++ b/src/lib/components/ListCard.svelte
@@ -78,7 +78,7 @@
                         </span>
                         {#if hasNewItems}
                             <iconify-icon
-                                class="text-primary-800-200 opacity-40"
+                                class="text-primary-800-200 size-2 opacity-40"
                                 icon="ion:ellipse-sharp"
                                 width="0.5rem"
                             ></iconify-icon>


### PR DESCRIPTION
## Description
Provide a clear and concise description of the changes in this PR.

Indicator was misaligned after upgrade

