### PR TITLE
feat(oidc): allow specifying the claims used for name and username

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -68,17 +68,21 @@ type OIDCConfig =
           autoRegister?: boolean | null;
           enableSync?: boolean | null;
           disableEmailVerification?: boolean | null;
+          nameClaim?: string | null;
+          usernameClaim?: string | null;
       }
     | {
           enable: true;
           discoveryUrl: string;
           clientId: string;
           clientSecret: string;
-          providerName?: string | null;
+          providerName: string | null | undefined;
           autoRedirect: boolean;
           autoRegister: boolean;
           enableSync: boolean;
           disableEmailVerification: boolean;
+          nameClaim: string | null | undefined;
+          usernameClaim: string | null | undefined;
       };
 
 type Config = {

--- a/src/lib/components/admin/Settings/Security/OIDC.svelte
+++ b/src/lib/components/admin/Settings/Security/OIDC.svelte
@@ -67,6 +67,42 @@
                 value={config.oidc.clientSecret}
             />
 
+            <Setting>
+                <label class="label" for="oidcNameClaim">
+                    <span>Name claim</span>
+                    <input
+                        id="oidcNameClaim"
+                        name="oidcNameClaim"
+                        class="input"
+                        autocomplete="off"
+                        placeholder="name"
+                        type="text"
+                        value={config.oidc.nameClaim}
+                    />
+                </label>
+                {#snippet description()}
+                    The claim to use for setting the user's name.
+                {/snippet}
+            </Setting>
+
+            <Setting>
+                <label class="label" for="oidcUsernameClaim">
+                    <span>Username claim</span>
+                    <input
+                        id="oidcUsernameClaim"
+                        name="oidcUsernameClaim"
+                        class="input"
+                        autocomplete="off"
+                        placeholder="username"
+                        type="text"
+                        value={config.oidc.usernameClaim}
+                    />
+                </label>
+                {#snippet description()}
+                    The claim to use for setting the user's username.
+                {/snippet}
+            </Setting>
+
             <Setting class="col-span-full">
                 <label class="checkbox-label">
                     <input

--- a/src/lib/server/config.ts
+++ b/src/lib/server/config.ts
@@ -31,7 +31,9 @@ enum ConfigKey {
     OIDC_AUTO_REDIRECT = "oidc.autoRedirect",
     OIDC_AUTO_REGISTER = "oidc.autoRegister",
     OIDC_ENABLE_SYNC = "oidc.enableSync",
-    OIDC_DISABLE_EMAIL_VERIFICATION = "oidc.disableEmailVerification"
+    OIDC_DISABLE_EMAIL_VERIFICATION = "oidc.disableEmailVerification",
+    OIDC_NAME_CLAIM = "oidc.nameClaim",
+    OIDC_USERNAME_CLAIM = "oidc.usernameClaim"
 }
 
 type Transformer<T> = (val: string | null, shouldMask?: boolean) => T;
@@ -73,7 +75,9 @@ const transformers: Record<ConfigKey, Transformer<unknown>> = {
     "oidc.autoRedirect": booleanTransformer,
     "oidc.autoRegister": booleanTransformer,
     "oidc.enableSync": booleanTransformer,
-    "oidc.disableEmailVerification": booleanTransformer
+    "oidc.disableEmailVerification": booleanTransformer,
+    "oidc.nameClaim": stringTransformer,
+    "oidc.usernameClaim": stringTransformer
 };
 
 const getDefaultConfig = (): Config => ({

--- a/src/lib/server/validations.ts
+++ b/src/lib/server/validations.ts
@@ -83,7 +83,9 @@ export const settingSchema = z.object({
     oidcAutoRedirect: z.coerce.boolean().default(false),
     oidcAutoRegister: z.coerce.boolean().default(false),
     oidcEnableSync: z.coerce.boolean().default(false),
-    oidcDisableEmailVerification: z.coerce.boolean().default(false)
+    oidcDisableEmailVerification: z.coerce.boolean().default(false),
+    oidcNameClaim: z.string().optional(),
+    oidcUsernameClaim: z.string().optional()
 });
 
 export const publicListCreateSchema = z.object({

--- a/src/routes/admin/settings/+page.server.ts
+++ b/src/routes/admin/settings/+page.server.ts
@@ -81,7 +81,9 @@ const generateConfig = (configData: z.infer<typeof settingSchema>) => {
               autoRedirect: configData.oidcAutoRedirect,
               autoRegister: configData.oidcAutoRegister,
               enableSync: configData.oidcEnableSync,
-              disableEmailVerification: configData.oidcDisableEmailVerification
+              disableEmailVerification: configData.oidcDisableEmailVerification,
+              nameClaim: configData.oidcNameClaim,
+              usernameClaim: configData.oidcUsernameClaim
           }
         : {
               enable: false,
@@ -92,7 +94,9 @@ const generateConfig = (configData: z.infer<typeof settingSchema>) => {
               autoRedirect: configData.oidcAutoRedirect,
               autoRegister: configData.oidcAutoRegister,
               enableSync: configData.oidcEnableSync,
-              disableEmailVerification: configData.oidcDisableEmailVerification
+              disableEmailVerification: configData.oidcDisableEmailVerification,
+              nameClaim: configData.oidcNameClaim,
+              usernameClaim: configData.oidcUsernameClaim
           };
 
     const newConfig: Config = {

--- a/src/routes/login/oidc/callback/+server.ts
+++ b/src/routes/login/oidc/callback/+server.ts
@@ -14,6 +14,7 @@ import type { UserInfoResponse } from "openid-client";
 export const POST: RequestHandler = async (event) => {
     const $t = await getFormatter();
     const userinfo = await handleCallback(event);
+    const config = await getConfig();
 
     logger.debug("Searching for existing user via oauthId: %s", userinfo.sub);
     // Find by oAuthId
@@ -30,12 +31,10 @@ export const POST: RequestHandler = async (event) => {
     });
     if (user) {
         logger.debug("Found existing user: %s", user.id);
-        await syncUserDetails(user, userinfo);
+        await syncUserDetails(user, userinfo, config);
         await authenticate(event, user.id);
     }
     logger.debug("No existing user found");
-
-    const config = await getConfig();
 
     if (!userinfo.email) {
         logger.error("No email found in userinfo");
@@ -72,7 +71,7 @@ export const POST: RequestHandler = async (event) => {
             }
         });
         logger.debug("Linked user account to OAuth via oauthId: %s", userinfo.sub);
-        await syncUserDetails(user, userinfo);
+        await syncUserDetails(user, userinfo, config);
         await authenticate(event, user.id);
     }
 
@@ -87,8 +86,8 @@ export const POST: RequestHandler = async (event) => {
     }
 
     const userData = {
-        name: userinfo.name ?? userinfo.email,
-        username: userinfo.preferred_username ?? userinfo.email,
+        name: extractClaim(config.oidc.nameClaim || "name", userinfo, userinfo.email)!,
+        username: extractClaim(config.oidc.usernameClaim || "preferred_username", userinfo, userinfo.email)!,
         email: userinfo.email,
         oauthId: userinfo.sub
     };
@@ -116,17 +115,35 @@ async function authenticate(event: RequestEvent, userId: string): Promise<never>
     redirect(302, redirectTo);
 }
 
-async function syncUserDetails(user: Pick<User, "id" | "name" | "email" | "username">, userinfo: UserInfoResponse) {
+function extractClaim(claim: string | null | undefined, userinfo: UserInfoResponse, fallback?: string) {
+    if (claim) {
+        const value = userinfo[claim];
+        if (value && typeof value === "string") {
+            return value;
+        }
+    }
+
+    logger.warn(`'${claim}' claim was not found in user's claims. Available claims: ${Object.keys(userinfo)}`);
+    return fallback;
+}
+
+async function syncUserDetails(
+    user: Pick<User, "id" | "name" | "email" | "username">,
+    userinfo: UserInfoResponse,
+    config: Config
+) {
     const updateData: Prisma.UserUpdateInput = {};
 
-    if (userinfo.name && user.name !== userinfo.name) {
-        updateData["name"] = userinfo.name;
-    }
     if (userinfo.email && user.email !== userinfo.email) {
         updateData["email"] = userinfo.email;
     }
-    if (userinfo.preferred_username && user.username !== userinfo.preferred_username) {
-        updateData["username"] = userinfo.preferred_username;
+    const name = extractClaim(config.oidc.nameClaim || "name", userinfo);
+    if (name && user.name !== name) {
+        updateData["name"] = name;
+    }
+    const username = extractClaim(config.oidc.usernameClaim || "preferred_username", userinfo);
+    if (username && user.username !== username) {
+        updateData["username"] = username;
     }
 
     if (Object.keys(updateData).length === 0) {
@@ -144,16 +161,13 @@ async function syncUserDetails(user: Pick<User, "id" | "name" | "email" | "usern
                 id: {
                     not: user.id
                 },
-                OR: [
-                    userinfo.email ? { email: userinfo.email } : {},
-                    userinfo.preferred_username ? { username: userinfo.preferred_username } : {}
-                ]
+                OR: [userinfo.email ? { email: userinfo.email } : {}, username ? { username } : {}]
             }
         });
 
         if (users.length > 0) {
             const conflictingEmail = users.find(({ email }) => email === userinfo.email) !== undefined;
-            const conflictingUsername = users.find(({ email }) => email === userinfo.preferred_username) !== undefined;
+            const conflictingUsername = users.find(({ email }) => email === username) !== undefined;
 
             const conflicts: Record<string, unknown> = {};
             if (conflictingEmail) {
@@ -161,7 +175,7 @@ async function syncUserDetails(user: Pick<User, "id" | "name" | "email" | "usern
                 updateData["email"] = undefined;
             }
             if (conflictingUsername) {
-                conflicts["username"] = userinfo.preferred_username;
+                conflicts["username"] = username;
                 updateData["username"] = undefined;
             }
             logger.warn("Unable to sync the following attributes due to conflicts: %s", conflicts);


### PR DESCRIPTION
## Description

Allows admins to specify the claims used in determining the name and username of user's from OIDC. Defaults to 'name' and 'preferred_username' to maintain backwards compatibility.

## Related Issues

Closes #632

## AI Disclosure
If AI tools were used in creating this PR (code, tests, docs, or design), briefly describe:

None
