### PR TITLE
feat: support comma-separated ORIGIN values for multi-origin setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ services:
       - ./data:/usr/src/app/data        # This is where the sqlite database will be stored
     environment:
       # ORIGIN: https://wishlist.example.com
+      # ORIGIN: https://wishlist.example.com,http://192.168.2.10:3280  # multi-origin (comma-separated)
       ORIGIN: http://192.168.2.10:3280 # The URL your users will be connecting to
       TOKEN_TIME: 72 # hours until signup and password reset tokens expire
 ```
@@ -69,7 +70,11 @@ You can now connect to your application at `http://<host>:3280`.
 
 ### Environment Variables
 
-`ORIGIN`: The URL your users will connect to e.g. `https://wishlist.domain.com`, `http://192.168.2.10:3280`. **Note**, if this value is an IP address, then it must include the exposed port of the application
+`ORIGIN`: The URL(s) your users will connect to. Supports comma-separated values for multiple origins (e.g., when accessed via both an external domain and an internal IP). The first value is used as the primary origin for email links. **Note**, if this value is an IP address, then it must include the exposed port of the application.
+
+Examples:
+- Single: `https://wishlist.domain.com`
+- Multiple: `https://wishlist.domain.com,http://192.168.1.10:3280`
 
 `TOKEN_TIME`: The amount of time (hours) that signup and password reset tokens are valid for
 

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,6 +1,5 @@
 import { dev } from "$app/environment";
 import { client } from "./prisma";
-import { env } from "$env/dynamic/private";
 import { encodeBase32LowerCaseNoPadding, encodeHexLowerCase } from "@oslojs/encoding";
 import type { Session, User } from "$lib/generated/prisma/client";
 import { sha256 } from "@oslojs/crypto/sha2";
@@ -8,11 +7,10 @@ import { error, redirect, type Cookies } from "@sveltejs/kit";
 import { getRequestEvent } from "$app/server";
 import { getFormatter } from "$lib/server/i18n";
 import { Role } from "$lib/schema";
+import { getOriginConfig } from "./origin";
 
 const EXPIRES_IN = 1000 * 60 * 60 * 24 * 30; // 30 days
 const REFRESH_TIME = 1000 * 60 * 60 * 24 * 15; // 15 days
-const origin = new URL(env.ORIGIN || "localhost:3280");
-
 export const sessionCookieName = "wishlist_session";
 
 export function generateSessionToken(): string {
@@ -93,7 +91,7 @@ export function setSessionTokenCookie(cookies: Cookies, token: string, expiresAt
         sameSite: "lax",
         expires: expiresAt,
         path: "/",
-        secure: !dev && origin.protocol === "https:"
+        secure: !dev && getOriginConfig().isSecure
     });
 }
 
@@ -103,7 +101,7 @@ export function deleteSessionTokenCookie(cookies: Cookies): void {
         sameSite: "lax",
         maxAge: 0,
         path: "/",
-        secure: !dev && origin.protocol === "https:"
+        secure: !dev && getOriginConfig().isSecure
     });
 }
 

--- a/src/lib/server/email.ts
+++ b/src/lib/server/email.ts
@@ -3,7 +3,7 @@ import Handlebars from "handlebars";
 import { readFile } from "fs";
 import type Mail from "nodemailer/lib/mailer";
 import { getConfig } from "$lib/server/config";
-import { env } from "$env/dynamic/private";
+import { getOriginConfig } from "$lib/server/origin";
 import { getFormatter } from "$lib/server/i18n";
 import { logger } from "$lib/server/logger";
 
@@ -88,7 +88,7 @@ export const sendSignupLink = async (to: string, inviteUrl: string) => {
     const $t = await getFormatter();
     const html = inviteTempl({
         url: inviteUrl,
-        baseUrl: env.ORIGIN || "http://localhost:5173",
+        baseUrl: getOriginConfig().primary.toString().replace(/\/$/, ""),
         wishlistLogoText: $t("a11y.wishlist-logo"),
         previewText: $t("email.invite-title"),
         titleText: $t("email.invite-title"),
@@ -108,7 +108,7 @@ export const sendPasswordReset = async (to: string, resetUrl: string) => {
     const $t = await getFormatter();
     const html = passResetTempl({
         url: resetUrl,
-        baseUrl: env.ORIGIN || "http://localhost:5173",
+        baseUrl: getOriginConfig().primary.toString().replace(/\/$/, ""),
         wishlistLogoText: $t("a11y.wishlist-logo"),
         previewText: $t("email.pw-reset-title"),
         titleText: $t("email.pw-reset-title"),

--- a/src/lib/server/origin.test.ts
+++ b/src/lib/server/origin.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock $env/dynamic/private before importing the module
+const mockEnv: { ORIGIN?: string } = {};
+
+vi.mock("$env/dynamic/private", () => ({
+    get env() {
+        return mockEnv;
+    }
+}));
+
+// Import after mock is set up
+const { getOriginConfig, _resetOriginConfig } = await import("./origin");
+
+describe("getOriginConfig", () => {
+    beforeEach(() => {
+        _resetOriginConfig();
+        delete mockEnv.ORIGIN;
+    });
+
+    it("single HTTPS origin (backward compatibility)", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com";
+        const config = getOriginConfig();
+        expect(config.origins).toHaveLength(1);
+        expect(config.primary.href).toBe("https://wishlist.example.com/");
+        expect(config.isSecure).toBe(true);
+    });
+
+    it("single HTTP origin (backward compatibility)", () => {
+        mockEnv.ORIGIN = "http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.origins).toHaveLength(1);
+        expect(config.primary.hostname).toBe("192.168.1.10");
+        expect(config.isSecure).toBe(false);
+    });
+
+    it("multiple origins", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com,http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.origins).toHaveLength(2);
+        expect(config.origins[0].href).toBe("https://wishlist.example.com/");
+        expect(config.origins[1].port).toBe("3280");
+    });
+
+    it("mixed protocols — isSecure true if ANY is HTTPS", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com,http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.isSecure).toBe(true);
+    });
+
+    it("all HTTP — isSecure is false", () => {
+        mockEnv.ORIGIN = "http://wishlist.example.com,http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.isSecure).toBe(false);
+    });
+
+    it("missing protocol — defaults to http://", () => {
+        mockEnv.ORIGIN = "192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.primary.protocol).toBe("http:");
+        expect(config.primary.hostname).toBe("192.168.1.10");
+    });
+
+    it("empty/undefined ORIGIN — defaults to http://localhost:3280", () => {
+        // ORIGIN not set
+        const config = getOriginConfig();
+        expect(config.primary.href).toBe("http://localhost:3280/");
+        expect(config.isSecure).toBe(false);
+    });
+
+    it("whitespace handling in comma-separated values", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com , http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.origins).toHaveLength(2);
+        expect(config.origins[0].hostname).toBe("wishlist.example.com");
+        expect(config.origins[1].port).toBe("3280");
+    });
+
+    it("primary is always the first entry", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com,http://192.168.1.10:3280";
+        const config = getOriginConfig();
+        expect(config.primary.hostname).toBe("wishlist.example.com");
+    });
+
+    it("trailing slash stripped from primary.toString()", () => {
+        mockEnv.ORIGIN = "https://wishlist.example.com";
+        const config = getOriginConfig();
+        const baseUrl = config.primary.toString().replace(/\/$/, "");
+        expect(baseUrl).toBe("https://wishlist.example.com");
+    });
+});

--- a/src/lib/server/origin.ts
+++ b/src/lib/server/origin.ts
@@ -1,0 +1,48 @@
+// Parse ORIGIN env var — supports comma-separated values
+// First entry is the "primary" origin (used for emails, canonical URLs)
+// Backward compatible: single value works exactly as before
+
+import { env } from "$env/dynamic/private";
+
+export interface OriginConfig {
+    origins: URL[];
+    primary: URL;
+    isSecure: boolean; // true if ANY origin uses HTTPS
+}
+
+function parseOrigins(): OriginConfig {
+    const raw = env.ORIGIN || "http://localhost:3280";
+    const entries = raw.split(",").map(s => s.trim()).filter(Boolean);
+
+    const origins = entries.map(entry => {
+        // Add protocol if missing
+        if (!entry.startsWith("http://") && !entry.startsWith("https://")) {
+            entry = `http://${entry}`;
+        }
+        return new URL(entry);
+    });
+
+    if (origins.length === 0) {
+        origins.push(new URL("http://localhost:3280"));
+    }
+
+    return {
+        origins,
+        primary: origins[0],
+        isSecure: origins.some(o => o.protocol === "https:")
+    };
+}
+
+let _config: OriginConfig | null = null;
+
+export function getOriginConfig(): OriginConfig {
+    if (!_config) {
+        _config = parseOrigins();
+    }
+    return _config;
+}
+
+// For testing — allows resetting cached config
+export function _resetOriginConfig(): void {
+    _config = null;
+}


### PR DESCRIPTION
## Summary

This PR extends the `ORIGIN` environment variable to accept comma-separated values, enabling Wishlist to be accessed via both external (reverse-proxied) and internal addresses simultaneously.

**Example:**
```
ORIGIN=https://wishlist.example.com,http://192.168.1.10:3280
```

## Problem

When running Wishlist behind a reverse proxy, users often need to access the app from both an external domain (e.g., `https://wishlist.example.com`) and an internal IP (e.g., `http://192.168.1.10:3280`). The current single-value `ORIGIN` only supports one address, forcing users to choose.

Related: #635 attempted to solve this with a separate `ALLOWED_ORIGINS` env var and custom CSRF hooks. This PR takes a simpler approach by extending the existing `ORIGIN` variable.

## Changes

### New: `src/lib/server/origin.ts`
- Parses `ORIGIN` as comma-separated values
- Exposes `getOriginConfig()` returning `{ origins[], primary, isSecure }`
- First entry is the "primary" origin (used for email links)
- `isSecure` is `true` if ANY origin uses HTTPS
- Cached after first parse

### Modified: `src/lib/server/auth.ts`
- Cookie `secure` flag now uses `getOriginConfig().isSecure`
- Removed direct `env.ORIGIN` usage

### Modified: `src/lib/server/email.ts`  
- Email base URLs now use `getOriginConfig().primary`
- Removed direct `env.ORIGIN` usage

### Not modified: `src/lib/server/openid.ts`
- OIDC already uses `event.url.origin` from the incoming request — no changes needed. Multi-origin works naturally.

### New: `src/lib/server/origin.test.ts`
- 9 unit tests covering: single origin, multi-origin, mixed protocols, defaults, whitespace, trailing slashes

### Updated: `README.md`
- Documentation updated to describe comma-separated support
- docker-compose example includes commented multi-origin example

## Backward Compatibility

✅ **Fully backward compatible** — a single `ORIGIN` value works exactly as before. No breaking changes.

## Testing

- [x] Unit tests for origin parsing (9 tests)
- [x] OIDC auth unaffected (uses `event.url.origin`, not `env.ORIGIN`)
- [x] Cookie secure flag correctly set when any origin is HTTPS
- [x] Email links use the primary (first) origin
- [x] Single-origin backward compatibility preserved

## Transparency Note

🤖 This PR was **AI-assisted** — code was generated and reviewed with the help of an AI coding agent (Claude/OpenClaw), with human review and approval of all changes before submission.

---

Ref: #635 (related prior attempt using a different approach)