### PR TITLE
fix: list sort for non-owners not respecting display order

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,6 @@
             "svelte-preprocess",
             "@tailwindcss/oxide"
         ]
-    }
+    },
+    "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,5 @@
             "svelte-preprocess",
             "@tailwindcss/oxide"
         ]
-    },
-    "packageManager": "pnpm@10.33.4+sha512.1c67b3b359b2d408119ba1ed289f34b8fc3c6873412bec6fd264fbdc82489e510fcbecb9ce9d22dae7f3b76269d8441046014bdca53b9979cd7a561ad631b800"
+    }
 }

--- a/src/lib/comparators.ts
+++ b/src/lib/comparators.ts
@@ -1,0 +1,25 @@
+import type { ItemOnListDTO } from "./dtos/item-dto";
+
+export function comparePrice(a: ItemOnListDTO, b: ItemOnListDTO, opts?: { reversed?: boolean; nullsLast?: boolean }) {
+    if (a.itemPrice === null && b.itemPrice === null) return 0;
+    if (a.itemPrice === null) return opts?.reversed && !opts?.nullsLast ? -1 : 1;
+    if (b.itemPrice === null) return opts?.reversed && !opts?.nullsLast ? 1 : -1;
+    const comp = a.itemPrice.value - b.itemPrice.value;
+    return opts?.reversed ? -comp : comp;
+}
+
+export function compareDisplayOrder(a: ItemOnListDTO, b: ItemOnListDTO) {
+    return (a.displayOrder ?? Infinity) - (b.displayOrder ?? Infinity);
+}
+
+export function compareClaimStatus(a: ItemOnListDTO, b: ItemOnListDTO, userId?: string) {
+    const userHasClaimedA = a.claims.find((c) => userId && c.claimedBy?.id === userId);
+    const userHasClaimedB = a.claims.find((c) => userId && c.claimedBy?.id === userId);
+    if (a.isClaimable && !userHasClaimedA && !(b.isClaimable && !userHasClaimedB)) {
+        return -1;
+    } else if (!(a.isClaimable && !userHasClaimedA) && b.isClaimable && !userHasClaimedB) {
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/src/lib/server/list.ts
+++ b/src/lib/server/list.ts
@@ -5,6 +5,7 @@ import { toItemOnListDTO } from "../dtos/item-mapper";
 import { getItemInclusions } from "./items";
 import type { Prisma } from "$lib/generated/prisma/client";
 import { getConfig } from "./config";
+import { comparePrice, compareDisplayOrder } from "$lib/comparators";
 
 export interface GetItemsOptions {
     filter: string | null;
@@ -211,12 +212,20 @@ export const getItems = async (listId: string, options: GetItemsOptions) => {
 
     if (options.sort === "price") {
         if (options.sortDir === "desc") {
-            itemDTOs.sort((a, b) => (b.itemPrice?.value ?? -Infinity) - (a.itemPrice?.value ?? -Infinity));
+            itemDTOs.sort((a, b) => {
+                const price = comparePrice(a, b, { reversed: true, nullsLast: true });
+                if (price !== 0) return price;
+                return compareDisplayOrder(a, b);
+            });
         } else {
-            itemDTOs.sort((a, b) => (a.itemPrice?.value ?? Infinity) - (b.itemPrice?.value ?? Infinity));
+            itemDTOs.sort((a, b) => {
+                const price = comparePrice(a, b);
+                if (price !== 0) return price;
+                return compareDisplayOrder(a, b);
+            });
         }
     } else {
-        itemDTOs.sort((a, b) => (a.displayOrder ?? Infinity) - (b.displayOrder ?? Infinity));
+        itemDTOs.sort(compareDisplayOrder);
     }
 
     return itemDTOs;

--- a/src/routes/lists/[id]/+page.svelte
+++ b/src/routes/lists/[id]/+page.svelte
@@ -26,6 +26,7 @@
     import ListStatistics from "$lib/components/wishlists/ListStatistics.svelte";
     import type { ActionReturn } from "svelte/action";
     import { toaster } from "$lib/components/toaster";
+    import { compareClaimStatus } from "$lib/comparators";
 
     const { data }: PageProps = $props();
     const t = getFormatter();
@@ -35,7 +36,10 @@
     let reordering = $state(false);
     let publicListUrl: URL | undefined = $state();
     let approvals = $derived(allItems.filter((item) => !item.approved));
-    let items = $derived(allItems.filter((item) => item.approved));
+    let items = $derived.by(() => {
+        const approvedItems = allItems.filter((item) => item.approved);
+        return sortItemsByClaimStatus(approvedItems);
+    });
     let listName = $derived.by(() => {
         if (data.list.name) {
             return data.list.name;
@@ -96,17 +100,9 @@
         if (data.list.owner.isMe) {
             return items;
         }
-        console.log(items);
         return items.toSorted((a, b) => {
-            const userHasClaimedA = a.claims.find((c) => data.user?.id && c.claimedBy?.id === data.user.id);
-            const userHasClaimedB = a.claims.find((c) => data.user?.id && c.claimedBy?.id === data.user.id);
-            if (a.isClaimable && !userHasClaimedA && !(b.isClaimable && !userHasClaimedB)) {
-                return -1;
-            } else if (!(a.isClaimable && !userHasClaimedA) && b.isClaimable && !userHasClaimedB) {
-                return 1;
-            } else {
-                return a.id - b.id;
-            }
+            const claimStatus = compareClaimStatus(a, b, data.user?.id);
+            return claimStatus;
         });
     };
 
@@ -391,7 +387,7 @@
                 </div>
             {/each}
         {:else}
-            {#each sortItemsByClaimStatus(items) as item (item.id)}
+            {#each items as item (item.id)}
                 <div
                     id="item-{item.id}-wrapper"
                     in:receive={{ key: item.id }}


### PR DESCRIPTION
## Description
A recent change introduced a regression in the sort order which was affecting non-owners viewing a list causing display order was not being honored.
The change was addressed and common comparator logic was extracted for clarity.

## Related Issues

Closes #716
