### PR TITLE
fix list hydration mismatch

### DIFF
--- a/src/lib/comparators.ts
+++ b/src/lib/comparators.ts
@@ -1,5 +1,30 @@
 import type { ItemOnListDTO } from "./dtos/item-dto";
 
+interface SortOptions {
+    sort: string | null;
+    dir: string | null;
+    userId?: string | null;
+    listOwnerId: string;
+}
+
+export function itemSorter(opts: SortOptions) {
+    return (a: ItemOnListDTO, b: ItemOnListDTO) => {
+        // Don't perform claim status sorting if on your own list
+        if (opts.listOwnerId !== opts.userId) {
+            const claimStatus = compareClaimStatus(a, b, opts.userId);
+            if (claimStatus != 0) return claimStatus;
+        }
+
+        if (opts.sort === "price") {
+            const reversed = opts.dir === "desc";
+            const price = comparePrice(a, b, { reversed, nullsLast: reversed });
+            if (price !== 0) return price;
+        }
+
+        return compareDisplayOrder(a, b);
+    };
+}
+
 export function comparePrice(a: ItemOnListDTO, b: ItemOnListDTO, opts?: { reversed?: boolean; nullsLast?: boolean }) {
     if (a.itemPrice === null && b.itemPrice === null) return 0;
     if (a.itemPrice === null) return opts?.reversed && !opts?.nullsLast ? -1 : 1;
@@ -12,9 +37,9 @@ export function compareDisplayOrder(a: ItemOnListDTO, b: ItemOnListDTO) {
     return (a.displayOrder ?? Infinity) - (b.displayOrder ?? Infinity);
 }
 
-export function compareClaimStatus(a: ItemOnListDTO, b: ItemOnListDTO, userId?: string) {
+export function compareClaimStatus(a: ItemOnListDTO, b: ItemOnListDTO, userId?: string | null) {
     const userHasClaimedA = a.claims.find((c) => userId && c.claimedBy?.id === userId);
-    const userHasClaimedB = a.claims.find((c) => userId && c.claimedBy?.id === userId);
+    const userHasClaimedB = b.claims.find((c) => userId && c.claimedBy?.id === userId);
     if (a.isClaimable && !userHasClaimedA && !(b.isClaimable && !userHasClaimedB)) {
         return -1;
     } else if (!(a.isClaimable && !userHasClaimedA) && b.isClaimable && !userHasClaimedB) {

--- a/src/lib/components/wishlists/ItemCard/components/ItemImage.svelte
+++ b/src/lib/components/wishlists/ItemCard/components/ItemImage.svelte
@@ -44,7 +44,7 @@
             <span class={[shrinkBadge ? "hidden md:block" : "block", "print:inline"]}>{$t("wishes.most-wanted")}</span>
         </div>
     {/if}
-    <Image {...props} alt={item.name} data-testid="image" referrerpolicy="no-referrer" src={imageUrl}>
+    <Image alt={item.name} data-testid="image" referrerpolicy="no-referrer" src={imageUrl}>
         {@render defaultImage($t)}
     </Image>
 </div>

--- a/src/lib/server/list.ts
+++ b/src/lib/server/list.ts
@@ -5,7 +5,7 @@ import { toItemOnListDTO } from "../dtos/item-mapper";
 import { getItemInclusions } from "./items";
 import type { Prisma } from "$lib/generated/prisma/client";
 import { getConfig } from "./config";
-import { comparePrice, compareDisplayOrder } from "$lib/comparators";
+import { itemSorter } from "$lib/comparators";
 
 export interface GetItemsOptions {
     filter: string | null;
@@ -204,31 +204,18 @@ export const getItems = async (listId: string, options: GetItemsOptions) => {
         include: getItemInclusions(list.id)
     });
 
-    const itemDTOs = items
-        // need to filter out items not on a list because prisma generates a stupid query
-        .filter((item) => item.lists.length > 0)
+    return items
+        .filter((item) => item.lists.length > 0) // need to filter out items not on a list because prisma generates a stupid query
         .map((i) => toItemOnListDTO(i, list.id))
-        .filter(claimFilter(options.filter, options.loggedInUserId));
-
-    if (options.sort === "price") {
-        if (options.sortDir === "desc") {
-            itemDTOs.sort((a, b) => {
-                const price = comparePrice(a, b, { reversed: true, nullsLast: true });
-                if (price !== 0) return price;
-                return compareDisplayOrder(a, b);
-            });
-        } else {
-            itemDTOs.sort((a, b) => {
-                const price = comparePrice(a, b);
-                if (price !== 0) return price;
-                return compareDisplayOrder(a, b);
-            });
-        }
-    } else {
-        itemDTOs.sort(compareDisplayOrder);
-    }
-
-    return itemDTOs;
+        .filter(claimFilter(options.filter, options.loggedInUserId))
+        .toSorted(
+            itemSorter({
+                sort: options.sort,
+                dir: options.sortDir,
+                userId: options.loggedInUserId,
+                listOwnerId: options.listOwnerId
+            })
+        );
 };
 
 const availableListSelection: Prisma.ListFindManyArgs["select"] = {

--- a/src/routes/lists/[id]/+page.svelte
+++ b/src/routes/lists/[id]/+page.svelte
@@ -26,7 +26,7 @@
     import ListStatistics from "$lib/components/wishlists/ListStatistics.svelte";
     import type { ActionReturn } from "svelte/action";
     import { toaster } from "$lib/components/toaster";
-    import { compareClaimStatus } from "$lib/comparators";
+    import { itemSorter } from "$lib/comparators";
 
     const { data }: PageProps = $props();
     const t = getFormatter();
@@ -36,10 +36,7 @@
     let reordering = $state(false);
     let publicListUrl: URL | undefined = $state();
     let approvals = $derived(allItems.filter((item) => !item.approved));
-    let items = $derived.by(() => {
-        const approvedItems = allItems.filter((item) => item.approved);
-        return sortItemsByClaimStatus(approvedItems);
-    });
+    let items = $derived(allItems.filter((item) => item.approved));
     let listName = $derived.by(() => {
         if (data.list.name) {
             return data.list.name;
@@ -91,19 +88,15 @@
         allItems = data.list.items;
     });
 
-    const updateDisplayOrder = (items: ItemOnListDTO[]) => {
-        items.forEach((it, idx) => (it.displayOrder = idx));
-    };
-
-    const sortItemsByClaimStatus = (items: ItemOnListDTO[]) => {
-        // When on own list, don't separate out claimed vs un-claimed
-        if (data.list.owner.isMe) {
-            return items;
-        }
-        return items.toSorted((a, b) => {
-            const claimStatus = compareClaimStatus(a, b, data.user?.id);
-            return claimStatus;
-        });
+    const sortItems = (items: ItemOnListDTO[]) => {
+        return items.toSorted(
+            itemSorter({
+                userId: data.user?.id,
+                sort: page.url.searchParams.get("sort"),
+                dir: page.url.searchParams.get("dir"),
+                listOwnerId: data.list.owner.id
+            })
+        );
     };
 
     const updateHash = async () => {
@@ -139,12 +132,13 @@
         if (!allItems.find((item) => item.id === updatedItem.id)) {
             addItem(updatedItem);
         }
-        allItems = allItems.map((item) => {
+        const updatedItems = allItems.map((item) => {
             if (item.id === updatedItem.id) {
                 return { ...item, ...updatedItem };
             }
             return item;
         });
+        allItems = sortItems(updatedItems);
     };
 
     const removeItem = (removedItem: { id: number }) => {
@@ -155,7 +149,7 @@
         if (!(addedItem.approved || data.list.owner.isMe)) {
             return;
         }
-        allItems = [...allItems, addedItem];
+        allItems = sortItems([...allItems, addedItem]);
     };
 
     const getOrCreatePublicList = async () => {
@@ -186,6 +180,10 @@
             destroy: zone.destroy
         };
     }
+
+    const updateDisplayOrder = (items: ItemOnListDTO[]) => {
+        items.forEach((it, idx) => (it.displayOrder = idx));
+    };
     const handleDnd = (e: CustomEvent) => {
         allItems = e.detail.items;
         updateDisplayOrder(allItems);


### PR DESCRIPTION
## Description
The most recent changes to the sorting by claim status on the client side caused hydration mismatch. This lead to item images not appearing with their intended item on the list. To fix, the same sorting logic is used on both the client and server side, so there is never a hydration mismatch.

## Related Issues

Closes #733 

## AI Disclosure
None
