### PR TITLE
fix: run wishlist as PID 1 in docker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,5 +8,6 @@ caddy start --config /usr/src/app/Caddyfile
 
 pnpm prisma migrate deploy && \
 pnpm prisma db seed && \
-pnpm db:patch && \
-pnpm start
+pnpm db:patch
+
+exec pnpm start


### PR DESCRIPTION
## Description
Updates entrypoint to run wishlist executable as PID 1 in docker so that it can be gracefully interrupted instead of forcefully after 10 seconds. Should improve the speed at which a "docker compose stop" command works.

## Related Issues
Relates to #747