### PR TITLE
Surface an error when product info can't be scraped

### DIFF
--- a/src/routes/api/product/+server.ts
+++ b/src/routes/api/product/+server.ts
@@ -9,6 +9,7 @@ import shopping from "$lib/server/shopping";
 import { parseAcceptLanguageHeader } from "$lib/i18n";
 import { getFormatter } from "$lib/server/i18n";
 import { requireLoginOrError } from "$lib/server/auth";
+import { logger } from "$lib/server/logger";
 import { env } from "$env/dynamic/private";
 
 const scraper = metascraper([shopping(), metascraperTitle(), metascraperImage()]);
@@ -31,11 +32,20 @@ const goShopping = async (targetUrl: URL, locales: string[]) => {
         }
     });
     const metadata = await scraper({ html: resp.body, url: resp.url });
+    logger.debug(
+        { url: targetUrl.toString(), status: resp.statusCode, bodyLength: resp.body?.length },
+        "Scraped product URL"
+    );
     return metadata;
 };
 
 const isCaptchaResponse = (metadata: Metadata) => {
     return metadata.image && metadata.image.toLocaleLowerCase().indexOf("captcha") >= 0;
+};
+
+const hasUsableMetadata = (metadata: Metadata) => {
+    const { name, title, image } = metadata as Metadata & { name?: string | null };
+    return Boolean(name || title || image);
 };
 
 const getUrlOrError = async (url: string) => {
@@ -64,6 +74,10 @@ export const GET: RequestHandler = async ({ request, url }) => {
             metadata = await getUrlOrError(metadata.url).then((url) => goShopping(url, locales));
         }
         if (isCaptchaResponse(metadata)) {
+            error(424, $t("errors.product-information-not-available"));
+        }
+
+        if (!hasUsableMetadata(metadata)) {
             error(424, $t("errors.product-information-not-available"));
         }
 


### PR DESCRIPTION
## Description
Pasting a URL from a bot-protected site (e.g. Smyths, behind Incapsula) autofilled
nothing and gave no hint why. The challenge page comes back as HTTP 200 with no
product markup, so `/api/product` returned 200 + empty metadata and the form just
stayed blank — with no server logs even at `LOG_LEVEL=debug`.

- Return 424 when a scrape yields no name/title/image, so the form shows the existing
  "unable to find product information" toast instead of silently blanking. It ignores
  url/hostname on purpose: those come from the request URL, not the page body, so
  they're set even on a failed fetch.
- Add a debug log (status, body length) so these failures are diagnosable with
  `LOG_LEVEL=debug`.

## Related Issues
N/A

## AI Disclosure
- **Tool:** Claude Code (Anthropic).
- **Used for:** diagnosing why bot-blocked URLs failed silently, and writing the change.
- **Verification:** ran `pnpm check` (0 errors), `pnpm lint`, and `pnpm format` in a
  Node 24 Docker container (no tracked changes); reviewed the diff manually.

## Checklist
Please confirm the following before requesting review:

- [x] I have tested my changes locally
- [x] I have ran `pnpm lint` locally
- [x] I have ran `pnpm format` locally
- [x] I have ran `pnpm check` locally
- [x] I have completed the AI Disclosure
- [x] My changes do not introduce new warnings or errors
